### PR TITLE
Add setting for default USB mode at startup

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -63,6 +63,7 @@ idf_component_register(
 		"menu/chat/lora_presets.c"
 		"menu/chat/messages.c"
 		"menu/settings_theme.c"
+		"menu/settings_usb_mode.c"
 		"radio_ota.c"
 		"lora_settings_handler.c"
 

--- a/main/device_settings.c
+++ b/main/device_settings.c
@@ -408,6 +408,22 @@ esp_err_t device_settings_set_meshcore_public_key(const char* value) {
     return device_settings_set_string("mc.public_key", value);
 }
 
+// USB mode
+
+esp_err_t device_settings_get_default_usb_mode(usb_mode_t* out_mode) {
+    uint8_t   value;
+    esp_err_t res = device_settings_get_u8("usb.defmode", USB_DEBUG, &value);
+    if (value > USB_DISABLED) {
+        value = USB_DEBUG;
+    }
+    *out_mode = (usb_mode_t)value;
+    return res;
+}
+
+esp_err_t device_settings_set_default_usb_mode(usb_mode_t mode) {
+    return device_settings_set_u8("usb.defmode", (uint8_t)mode);
+}
+
 // Theme
 
 esp_err_t device_settings_get_theme(theme_setting_t* out_theme) {

--- a/main/device_settings.h
+++ b/main/device_settings.h
@@ -56,6 +56,11 @@ esp_err_t device_settings_set_meshcore_private_key(const char* value);
 esp_err_t device_settings_get_meshcore_public_key(char* out_value, size_t max_length);
 esp_err_t device_settings_set_meshcore_public_key(const char* value);
 
+// USB mode
+#include "usb_device.h"
+esp_err_t device_settings_get_default_usb_mode(usb_mode_t* out_mode);
+esp_err_t device_settings_set_default_usb_mode(usb_mode_t mode);
+
 // Theme
 
 typedef enum {

--- a/main/menu/settings_usb_mode.c
+++ b/main/menu/settings_usb_mode.c
@@ -1,0 +1,108 @@
+#include <stdbool.h>
+#include "bsp/input.h"
+#include "common/display.h"
+#include "common/theme.h"
+#include "device_settings.h"
+#include "freertos/idf_additions.h"
+#include "gui_menu.h"
+#include "gui_style.h"
+#include "icons.h"
+#include "menu/message_dialog.h"
+#include "pax_gfx.h"
+#include "pax_matrix.h"
+#include "pax_types.h"
+#include "usb_device.h"
+
+static void render(menu_t* menu, bool partial, bool icons) {
+    pax_buf_t*   buffer = display_get_buffer();
+    gui_theme_t* theme  = get_theme();
+
+    int header_height = theme->header.height + (theme->header.vertical_margin * 2);
+    int footer_height = theme->footer.height + (theme->footer.vertical_margin * 2);
+
+    pax_vec2_t position = {
+        .x0 = theme->menu.horizontal_margin + theme->menu.horizontal_padding,
+        .y0 = header_height + theme->menu.vertical_margin + theme->menu.vertical_padding,
+        .x1 = pax_buf_get_width(buffer) - theme->menu.horizontal_margin - theme->menu.horizontal_padding,
+        .y1 = pax_buf_get_height(buffer) - footer_height - theme->menu.vertical_margin - theme->menu.vertical_padding,
+    };
+
+    if (!partial || icons) {
+        render_base_screen_statusbar(
+            buffer, theme, !partial, !partial || icons, !partial,
+            ((gui_element_icontext_t[]){{get_icon(ICON_USB), "Default USB mode"}}), 1,
+            ((gui_element_icontext_t[]){{get_icon(ICON_ESC), "/"}, {get_icon(ICON_F1), "Back"}}), 2,
+            ((gui_element_icontext_t[]){{NULL, "↑ / ↓ | ⏎ Select"}}), 1);
+    }
+
+    menu_render(buffer, menu, position, theme, partial);
+    display_blit_buffer(buffer);
+}
+
+static void update_menu(menu_t* menu) {
+    usb_mode_t mode = USB_DEBUG;
+    device_settings_get_default_usb_mode(&mode);
+    for (size_t i = 0; i < menu_get_length(menu); i++) {
+        if ((usb_mode_t)menu_get_callback_args(menu, i) == mode) {
+            menu_set_value(menu, i, "X");
+        } else {
+            menu_set_value(menu, i, "");
+        }
+    }
+}
+
+void menu_settings_usb_mode(void) {
+    QueueHandle_t input_event_queue = NULL;
+    ESP_ERROR_CHECK(bsp_input_get_queue(&input_event_queue));
+
+    menu_t menu = {0};
+    menu_initialize(&menu);
+    menu_insert_item_value(&menu, "Debug (JTAG)", "", NULL, (void*)USB_DEBUG, -1);
+    menu_insert_item_value(&menu, "USB device (BadgeLink)", "", NULL, (void*)USB_DEVICE, -1);
+
+    update_menu(&menu);
+    render(&menu, false, true);
+    while (1) {
+        bsp_input_event_t event;
+        if (xQueueReceive(input_event_queue, &event, pdMS_TO_TICKS(1000)) == pdTRUE) {
+            switch (event.type) {
+                case INPUT_EVENT_TYPE_NAVIGATION: {
+                    if (event.args_navigation.state) {
+                        switch (event.args_navigation.key) {
+                            case BSP_INPUT_NAVIGATION_KEY_ESC:
+                            case BSP_INPUT_NAVIGATION_KEY_F1:
+                            case BSP_INPUT_NAVIGATION_KEY_GAMEPAD_B:
+                                menu_free(&menu);
+                                return;
+                            case BSP_INPUT_NAVIGATION_KEY_UP:
+                                menu_navigate_previous(&menu);
+                                render(&menu, false, false);
+                                break;
+                            case BSP_INPUT_NAVIGATION_KEY_DOWN:
+                                menu_navigate_next(&menu);
+                                render(&menu, false, false);
+                                break;
+                            case BSP_INPUT_NAVIGATION_KEY_RETURN:
+                            case BSP_INPUT_NAVIGATION_KEY_GAMEPAD_A:
+                            case BSP_INPUT_NAVIGATION_KEY_JOYSTICK_PRESS: {
+                                usb_mode_t selected =
+                                    (usb_mode_t)menu_get_callback_args(&menu, menu_get_position(&menu));
+                                device_settings_set_default_usb_mode(selected);
+                                update_menu(&menu);
+                                render(&menu, false, false);
+                                break;
+                            }
+                            default:
+                                break;
+                        }
+                    }
+                    break;
+                }
+                default:
+                    break;
+            }
+        } else {
+            render(&menu, true, true);
+        }
+    }
+}

--- a/main/menu/settings_usb_mode.h
+++ b/main/menu/settings_usb_mode.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void menu_settings_usb_mode(void);

--- a/main/menu/tools.c
+++ b/main/menu/tools.c
@@ -23,6 +23,7 @@
 #include "radio_update.h"
 #include "settings_clock.h"
 #include "settings_repository.h"
+#include "settings_usb_mode.h"
 
 #if defined(CONFIG_BSP_TARGET_TANMATSU) || defined(CONFIG_BSP_TARGET_KONSOOL)
 #define FOOTER_LEFT  ((gui_element_icontext_t[]){{get_icon(ICON_ESC), "/"}, {get_icon(ICON_F1), "Back"}}), 2
@@ -42,6 +43,7 @@ typedef enum {
     ACTION_RADIO_OTA,
     ACTION_HARDWARE_TEST,
     ACTION_DOWNLOAD_ICONS,
+    ACTION_USB_MODE,
 } menu_home_action_t;
 
 static void radio_update_v2(void) {
@@ -69,6 +71,9 @@ static void execute_action(pax_buf_t* fb, menu_home_action_t action, gui_theme_t
             break;
         case ACTION_DOWNLOAD_ICONS:
             download_icons(false);
+            break;
+        case ACTION_USB_MODE:
+            menu_settings_usb_mode();
             break;
         default:
             break;
@@ -104,6 +109,7 @@ void menu_tools(void) {
                           get_icon(ICON_RELEASE_ALERT));
     menu_insert_item_icon(&menu, "Hardware test", NULL, (void*)ACTION_HARDWARE_TEST, -1, get_icon(ICON_BUG_REPORT));
     menu_insert_item_icon(&menu, "Download icons", NULL, (void*)ACTION_DOWNLOAD_ICONS, -1, get_icon(ICON_COLORS));
+    menu_insert_item_icon(&menu, "Default USB mode", NULL, (void*)ACTION_USB_MODE, -1, get_icon(ICON_USB));
 
     pax_buf_t*   buffer = display_get_buffer();
     gui_theme_t* theme  = get_theme();

--- a/main/usb_device.c
+++ b/main/usb_device.c
@@ -11,6 +11,7 @@
 #include <string.h>
 #include "badgelink.h"
 #include "bsp/device.h"
+#include "device_settings.h"
 #include "esp_log.h"
 #include "esp_mac.h"
 #include "esp_timer.h"
@@ -256,8 +257,11 @@ void usb_initialize(void) {
 
     ESP_LOGI(TAG, "USB initialization DONE");
 
-    // vTaskDelay(pdMS_TO_TICKS(10000));
-    // usb_serial_jtag_ll_phy_select(0);
+    usb_mode_t default_mode = USB_DEBUG;
+    device_settings_get_default_usb_mode(&default_mode);
+    if (default_mode != USB_DEBUG) {
+        usb_mode_set(default_mode);
+    }
 }
 
 uint16_t webusb_esp32_status                      = 0x0000;


### PR DESCRIPTION
## Summary
- Adds a persistent NVS setting (`usb.defmode`) to choose whether the device boots into Debug (JTAG) or USB Device (BadgeLink) mode
- Setting is accessible from Settings > Tools > "Default USB mode"
- Applied during USB initialization on startup

## Test plan
- [ ] Flash and verify default boot mode is still Debug (JTAG) with no setting stored
- [ ] Change default to USB Device via Settings > Tools > Default USB mode
- [ ] Reboot and verify device starts in USB Device (BadgeLink) mode
- [ ] Change back to Debug and verify it persists across reboot

🤖 Generated with [Claude Code](https://claude.com/claude-code)