### PR TITLE
Advanced app management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,6 @@ sdkconfig_*
 REPOLAYOUT.md
 CLAUDE.md
 components/badgeteam__badgelink/
+components/nicolaielectronics__tanmatsu_coprocessor/
+components/badgeteam__badge-bsp/
 .vscode

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -90,6 +90,8 @@ idf_component_register(
 		"app_management.c"
 		"ntp.c"
 		"device_settings.c"
+		"appfs_settings.c"
+		"app_usage.c"
 		"fastopen.c"
 		"global_event_handler.c"
 		"bootloader_update.c"

--- a/main/app_management.c
+++ b/main/app_management.c
@@ -1,12 +1,11 @@
 #include "app_management.h"
 #include <ctype.h>
-#include <dirent.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/stat.h>
 #include "app_metadata_parser.h"
 #include "app_usage.h"
 #include "appfs.h"
+#include "appfs_settings.h"
 #include "bsp/device.h"
 #include "cJSON.h"
 #include "esp_err.h"
@@ -370,47 +369,27 @@ bool app_mgmt_has_binary_in_install_dir(const char* slug) {
 }
 
 esp_err_t app_mgmt_copy_appfs_to_install_dir(const char* slug) {
-    // Find which install directory exists for this app
-    char        app_dir[256] = {0};
+    // Find which base path has an install directory for this app
     const char* base_paths[] = {"/int/apps", "/sd/apps"};
-    bool        found        = false;
+    const char* found_base   = NULL;
+    char        app_dir[256] = {0};
     for (int i = 0; i < 2; i++) {
         snprintf(app_dir, sizeof(app_dir), "%s/%s", base_paths[i], slug);
         if (fs_utils_exists(app_dir)) {
-            found = true;
+            found_base = base_paths[i];
             break;
         }
     }
-    if (!found) {
+    if (found_base == NULL) {
         ESP_LOGE(TAG, "No install directory found for app %s", slug);
         return ESP_ERR_NOT_FOUND;
     }
 
     // Get executable filename from metadata
+    // get_executable_revision(base, slug, ...) returns path as "{base}/{slug}/{filename}"
     uint32_t revision  = 0;
     char*    exec_path = NULL;
-    if (!get_executable_revision(app_dir, slug, &revision, &exec_path)) {
-        ESP_LOGE(TAG, "Failed to get executable info for app %s", slug);
-        return ESP_FAIL;
-    }
-
-    // Note: get_executable_revision builds exec_path as "{base}/{slug}/{filename}"
-    // but we called it with app_dir which is already "{base}/{slug}",
-    // so exec_path is "{base}/{slug}/{slug}/{filename}" which is wrong.
-    // We need to call it with the base path instead.
-    free(exec_path);
-    exec_path = NULL;
-
-    // Re-derive base path from app_dir by finding the parent
-    // app_dir is like "/int/apps/slug" or "/sd/apps/slug"
-    char base_path[256] = {0};
-    strncpy(base_path, app_dir, sizeof(base_path) - 1);
-    char* last_slash = strrchr(base_path, '/');
-    if (last_slash != NULL) {
-        *last_slash = '\0';
-    }
-
-    if (!get_executable_revision(base_path, slug, &revision, &exec_path)) {
+    if (!get_executable_revision(found_base, slug, &revision, &exec_path)) {
         ESP_LOGE(TAG, "Failed to get executable info for app %s", slug);
         return ESP_FAIL;
     }
@@ -501,6 +480,21 @@ esp_err_t app_mgmt_remove_from_appfs(const char* slug) {
     return appfsDeleteFile(slug);
 }
 
+char* app_mgmt_find_firmware_path(const char* slug) {
+    const char* base_paths[] = {"/int/apps", "/sd/apps"};
+    for (int i = 0; i < 2; i++) {
+        uint32_t revision  = 0;
+        char*    exec_path = NULL;
+        if (get_executable_revision(base_paths[i], slug, &revision, &exec_path)) {
+            if (exec_path != NULL && fs_utils_exists(exec_path)) {
+                return exec_path;
+            }
+            free(exec_path);
+        }
+    }
+    return NULL;
+}
+
 esp_err_t app_mgmt_ensure_in_appfs(const char* slug, const char* name, uint32_t revision, const char* firmware_path) {
     if (appfsExists(slug)) {
         return ESP_OK;
@@ -526,6 +520,25 @@ esp_err_t app_mgmt_ensure_in_appfs(const char* slug, const char* name, uint32_t 
     }
 
     return app_mgmt_install_from_file(slug, name, revision, (char*)firmware_path);
+}
+
+esp_err_t app_mgmt_cache_to_appfs(const char* slug, const char* name, uint32_t revision, const char* firmware_path) {
+    esp_err_t res = app_mgmt_ensure_in_appfs(slug, name, revision, firmware_path);
+    if (res == ESP_ERR_NO_MEM) {
+        uint8_t auto_cleanup = 0;
+        appfs_settings_get_auto_cleanup(&auto_cleanup);
+        if (auto_cleanup) {
+            FILE* fd = fastopen(firmware_path, "rb");
+            if (fd != NULL) {
+                size_t file_size    = fs_utils_get_file_size(fd);
+                fastclose(fd);
+                size_t rounded_size = (file_size + (SPI_FLASH_MMU_PAGE_SIZE - 1)) & (~(SPI_FLASH_MMU_PAGE_SIZE - 1));
+                app_mgmt_appfs_evict_lru(rounded_size);
+                res = app_mgmt_ensure_in_appfs(slug, name, revision, firmware_path);
+            }
+        }
+    }
+    return res;
 }
 
 // Comparison function for qsort — sort by timestamp ascending (oldest first)
@@ -601,42 +614,6 @@ esp_err_t app_mgmt_appfs_evict_lru(size_t needed_bytes) {
 
 // --- App move between storage locations ---
 
-static uint64_t get_directory_size(const char* path) {
-    struct stat st;
-    if (stat(path, &st) != 0) {
-        return 0;
-    }
-
-    if (!S_ISDIR(st.st_mode)) {
-        return st.st_size;
-    }
-
-    DIR* dir = opendir(path);
-    if (dir == NULL) {
-        return 0;
-    }
-
-    uint64_t       total = 0;
-    struct dirent* entry;
-    while ((entry = readdir(dir)) != NULL) {
-        if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) {
-            continue;
-        }
-
-        size_t full_len  = strlen(path) + strlen(entry->d_name) + 2;
-        char*  full_path = malloc(full_len);
-        if (full_path == NULL) {
-            break;
-        }
-        snprintf(full_path, full_len, "%s/%s", path, entry->d_name);
-        total += get_directory_size(full_path);
-        free(full_path);
-    }
-
-    closedir(dir);
-    return total;
-}
-
 esp_err_t app_mgmt_move(const char* slug, app_mgmt_location_t from, app_mgmt_location_t to) {
     const char* src_base = app_mgmt_location_to_path(from);
     const char* dst_base = app_mgmt_location_to_path(to);
@@ -655,7 +632,7 @@ esp_err_t app_mgmt_move(const char* slug, app_mgmt_location_t from, app_mgmt_loc
     }
 
     // Check free space on target filesystem
-    uint64_t dir_size = get_directory_size(src_path);
+    uint64_t dir_size = fs_utils_get_directory_size(src_path);
     if (dir_size == 0) {
         ESP_LOGE(TAG, "Failed to calculate directory size for %s", src_path);
         return ESP_FAIL;
@@ -723,7 +700,7 @@ bool app_mgmt_can_move(const char* slug, app_mgmt_location_t from, app_mgmt_loca
         return false;
     }
 
-    uint64_t dir_size = get_directory_size(src_path);
+    uint64_t dir_size = fs_utils_get_directory_size(src_path);
     if (dir_size == 0) {
         return false;
     }

--- a/main/app_management.c
+++ b/main/app_management.c
@@ -546,8 +546,13 @@ esp_err_t app_mgmt_appfs_evict_lru(size_t needed_bytes) {
     // Collect appfs entries that have a backup in the install directory.
     // Apps without install dirs (dev/legacy apps only in appfs) are never auto-evicted
     // since removing them would permanently lose the binary.
-    appfs_usage_entry_t entries[128];
-    size_t              count = 0;
+    // Heap-allocated to avoid stack overflow in the deep call chain.
+    appfs_usage_entry_t* entries = malloc(sizeof(appfs_usage_entry_t) * 128);
+    if (entries == NULL) {
+        ESP_LOGE(TAG, "Failed to allocate memory for LRU eviction");
+        return ESP_ERR_NO_MEM;
+    }
+    size_t count = 0;
 
     appfs_handle_t appfs_fd = appfsNextEntry(APPFS_INVALID_FD);
     while (appfs_fd != APPFS_INVALID_FD && count < 128) {
@@ -567,6 +572,7 @@ esp_err_t app_mgmt_appfs_evict_lru(size_t needed_bytes) {
 
     if (count == 0) {
         ESP_LOGW(TAG, "No appfs entries to evict");
+        free(entries);
         return ESP_ERR_NO_MEM;
     }
 
@@ -576,11 +582,14 @@ esp_err_t app_mgmt_appfs_evict_lru(size_t needed_bytes) {
     // Evict entries until we have enough space
     for (size_t i = 0; i < count; i++) {
         if (appfsGetFreeMem() >= needed_bytes) {
+            free(entries);
             return ESP_OK;
         }
         ESP_LOGI(TAG, "Evicting %s from AppFS (last used: %u)", entries[i].slug, entries[i].timestamp);
         app_mgmt_remove_from_appfs(entries[i].slug);
     }
+
+    free(entries);
 
     if (appfsGetFreeMem() >= needed_bytes) {
         return ESP_OK;

--- a/main/app_management.c
+++ b/main/app_management.c
@@ -560,15 +560,16 @@ esp_err_t app_mgmt_appfs_evict_lru(size_t needed_bytes) {
     // Apps without install dirs (dev/legacy apps only in appfs) are never auto-evicted
     // since removing them would permanently lose the binary.
     // Heap-allocated to avoid stack overflow in the deep call chain.
-    appfs_usage_entry_t* entries = malloc(sizeof(appfs_usage_entry_t) * 128);
+    appfs_usage_entry_t* entries = malloc(sizeof(appfs_usage_entry_t) * MAX_NUM_APPS);
     if (entries == NULL) {
         ESP_LOGE(TAG, "Failed to allocate memory for LRU eviction");
         return ESP_ERR_NO_MEM;
     }
-    size_t count = 0;
 
+    // Collect evictable entries
+    size_t         count   = 0;
     appfs_handle_t appfs_fd = appfsNextEntry(APPFS_INVALID_FD);
-    while (appfs_fd != APPFS_INVALID_FD && count < 128) {
+    while (appfs_fd != APPFS_INVALID_FD && count < MAX_NUM_APPS) {
         const char* slug = NULL;
         appfsEntryInfoExt(appfs_fd, &slug, NULL, NULL, NULL);
         if (slug != NULL && app_mgmt_can_uncache(slug)) {

--- a/main/app_management.c
+++ b/main/app_management.c
@@ -57,12 +57,6 @@ esp_err_t app_mgmt_install(const char* repository_url, const char* slug, app_mgm
         return ESP_ERR_INVALID_RESPONSE;
     }
 
-    char*  name     = NULL;
-    cJSON* name_obj = cJSON_GetObjectItem(metadata.json, "name");
-    if (name_obj != NULL && cJSON_IsString(name_obj)) {
-        name = name_obj->valuestring;
-    }
-
     repository_json_data_t information = {0};
     if (!load_information(repository_url, &information)) {
         free_repository_data_json(&metadata);
@@ -259,10 +253,16 @@ esp_err_t app_mgmt_install(const char* repository_url, const char* slug, app_mgm
         }
     }
 
+    // Remove stale appfs cache if present (new version on filesystem should take precedence)
+    if (appfsExists(slug)) {
+        ESP_LOGI(TAG, "Removing stale AppFS cache for %s", slug);
+        appfsDeleteFile(slug);
+    }
+
     free_repository_data_json(&metadata);
     free_repository_data_json(&information);
     ESP_LOGI(TAG, "App %s installed successfully at %s", slug, base_path);
-    return ESP_OK;  // Placeholder return value
+    return ESP_OK;
 }
 
 esp_err_t app_mgmt_uninstall(const char* slug, app_mgmt_location_t location) {

--- a/main/app_management.c
+++ b/main/app_management.c
@@ -1,11 +1,17 @@
 #include "app_management.h"
 #include <ctype.h>
+#include <dirent.h>
+#include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
+#include "app_metadata_parser.h"
+#include "app_usage.h"
 #include "appfs.h"
 #include "bsp/device.h"
 #include "cJSON.h"
 #include "esp_err.h"
 #include "esp_log.h"
+#include "esp_vfs_fat.h"
 #include "fastopen.h"
 #include "filesystem_utils.h"
 #include "http_download.h"
@@ -206,16 +212,11 @@ esp_err_t app_mgmt_install(const char* repository_url, const char* slug, app_mgm
         return ESP_ERR_INVALID_RESPONSE;
     }
 
-    // Install binary to AppFS
+    // Download and store executable binary to the install directory (not to AppFS)
+    // The binary will be loaded into AppFS on-demand when the app is launched
     cJSON* type = cJSON_GetObjectItem(application, "type");
     if (type != NULL && cJSON_IsString(type) && strcmp(type->valuestring, "appfs") == 0 &&
         strlen(type->valuestring) == strlen("appfs")) {
-        uint32_t revision     = 0;
-        cJSON*   revision_obj = cJSON_GetObjectItem(application, "revision");
-        if (revision_obj != NULL && cJSON_IsNumber(revision_obj)) {
-            revision = (uint32_t)revision_obj->valueint;
-        }
-
         char*  executable     = NULL;
         cJSON* executable_obj = cJSON_GetObjectItem(application, "executable");
         if (executable_obj != NULL && cJSON_IsString(executable_obj)) {
@@ -226,64 +227,18 @@ esp_err_t app_mgmt_install(const char* repository_url, const char* slug, app_mgm
             char file_url[256] = {0};
             snprintf(file_url, sizeof(file_url), "%s/%s/%s/%s", repository_url, repository_data_url, slug, executable);
 
-            uint8_t* file_data = NULL;
-            size_t   file_size = 0;
+            char target_path[512] = {0};
+            snprintf(target_path, sizeof(target_path), "%s/%s", app_path, executable);
 
             char status_text[64] = {0};
             snprintf(status_text, sizeof(status_text), "Downloading executable '%s'...", executable);
-            if (!download_ram(file_url, &file_data, &file_size, download_callback, status_text)) {
+            if (!download_file(file_url, target_path, download_callback, status_text)) {
                 ESP_LOGE(TAG, "Failed to download executable: %s", executable);
                 free_repository_data_json(&metadata);
                 free_repository_data_json(&information);
                 app_mgmt_uninstall(slug, location);
                 return ESP_FAIL;
             }
-
-            appfs_handle_t appfs_file = APPFS_INVALID_FD;
-            if (appfsCreateFileExt(slug, name, revision, file_size, &appfs_file) != ESP_OK) {
-                free(file_data);
-                free_repository_data_json(&metadata);
-                free_repository_data_json(&information);
-                app_mgmt_uninstall(slug, location);
-                ESP_LOGE(TAG, "Failed to create appfs file: %s", slug);
-                return ESP_FAIL;
-            }
-
-            int rounded_size = (file_size + (SPI_FLASH_MMU_PAGE_SIZE - 1)) & (~(SPI_FLASH_MMU_PAGE_SIZE - 1));
-            if (appfsErase(appfs_file, 0, rounded_size) != ESP_OK) {
-                free(file_data);
-                free_repository_data_json(&metadata);
-                free_repository_data_json(&information);
-                app_mgmt_uninstall(slug, location);
-                ESP_LOGE(TAG, "Failed to erase appfs file: %s", slug);
-                return ESP_FAIL;
-            }
-
-            if (appfsWrite(appfs_file, 0, file_data, file_size) != ESP_OK) {
-                free(file_data);
-                free_repository_data_json(&metadata);
-                free_repository_data_json(&information);
-                app_mgmt_uninstall(slug, location);
-                ESP_LOGE(TAG, "Failed to install executable to AppFS: %s", slug);
-                return ESP_FAIL;
-            }
-
-            if (location == APP_MGMT_LOCATION_SD) {
-                snprintf(file_path, sizeof(file_path), "%s/%s", app_path, executable);
-                FILE* fd = fastopen(file_path, "wb");
-                if (fd == NULL) {
-                    free(file_data);
-                    free_repository_data_json(&metadata);
-                    free_repository_data_json(&information);
-                    app_mgmt_uninstall(slug, location);
-                    ESP_LOGE(TAG, "Failed to write executable to SD card: %s", slug);
-                    return ESP_FAIL;
-                }
-                fwrite(file_data, 1, file_size, fd);
-                fastclose(fd);
-            }
-
-            free(file_data);
         }
     }
 
@@ -343,6 +298,9 @@ esp_err_t app_mgmt_uninstall(const char* slug, app_mgmt_location_t location) {
         }
     }
 
+    // Clean up last-used timestamp from NVS
+    app_usage_remove_last_used(slug);
+
     return res;
 }
 
@@ -389,4 +347,384 @@ esp_err_t app_mgmt_install_from_file(const char* slug, const char* name, uint32_
     free(file_data);
 
     return ESP_OK;
+}
+
+// --- AppFS cache management ---
+
+bool app_mgmt_has_binary_in_install_dir(const char* slug) {
+    const char* base_paths[] = {"/int/apps", "/sd/apps"};
+    for (int i = 0; i < 2; i++) {
+        uint32_t revision    = 0;
+        char*    exec_path   = NULL;
+        if (get_executable_revision(base_paths[i], slug, &revision, &exec_path)) {
+            if (exec_path != NULL) {
+                bool exists = fs_utils_exists(exec_path);
+                free(exec_path);
+                if (exists) {
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
+}
+
+esp_err_t app_mgmt_copy_appfs_to_install_dir(const char* slug) {
+    // Find which install directory exists for this app
+    char        app_dir[256] = {0};
+    const char* base_paths[] = {"/int/apps", "/sd/apps"};
+    bool        found        = false;
+    for (int i = 0; i < 2; i++) {
+        snprintf(app_dir, sizeof(app_dir), "%s/%s", base_paths[i], slug);
+        if (fs_utils_exists(app_dir)) {
+            found = true;
+            break;
+        }
+    }
+    if (!found) {
+        ESP_LOGE(TAG, "No install directory found for app %s", slug);
+        return ESP_ERR_NOT_FOUND;
+    }
+
+    // Get executable filename from metadata
+    uint32_t revision  = 0;
+    char*    exec_path = NULL;
+    if (!get_executable_revision(app_dir, slug, &revision, &exec_path)) {
+        ESP_LOGE(TAG, "Failed to get executable info for app %s", slug);
+        return ESP_FAIL;
+    }
+
+    // Note: get_executable_revision builds exec_path as "{base}/{slug}/{filename}"
+    // but we called it with app_dir which is already "{base}/{slug}",
+    // so exec_path is "{base}/{slug}/{slug}/{filename}" which is wrong.
+    // We need to call it with the base path instead.
+    free(exec_path);
+    exec_path = NULL;
+
+    // Re-derive base path from app_dir by finding the parent
+    // app_dir is like "/int/apps/slug" or "/sd/apps/slug"
+    char base_path[256] = {0};
+    strncpy(base_path, app_dir, sizeof(base_path) - 1);
+    char* last_slash = strrchr(base_path, '/');
+    if (last_slash != NULL) {
+        *last_slash = '\0';
+    }
+
+    if (!get_executable_revision(base_path, slug, &revision, &exec_path)) {
+        ESP_LOGE(TAG, "Failed to get executable info for app %s", slug);
+        return ESP_FAIL;
+    }
+
+    // Read binary from appfs
+    appfs_handle_t appfs_fd = appfsOpen(slug);
+    if (appfs_fd == APPFS_INVALID_FD) {
+        ESP_LOGE(TAG, "Failed to open appfs entry for %s", slug);
+        free(exec_path);
+        return ESP_FAIL;
+    }
+
+    int appfs_size = 0;
+    appfsEntryInfoExt(appfs_fd, NULL, NULL, NULL, &appfs_size);
+    if (appfs_size <= 0) {
+        ESP_LOGE(TAG, "Invalid appfs file size for %s", slug);
+        free(exec_path);
+        return ESP_FAIL;
+    }
+
+    uint8_t* file_data = malloc(appfs_size);
+    if (file_data == NULL) {
+        ESP_LOGE(TAG, "Failed to allocate memory for appfs read (%d bytes)", appfs_size);
+        free(exec_path);
+        return ESP_ERR_NO_MEM;
+    }
+
+    if (appfsRead(appfs_fd, 0, file_data, appfs_size) != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to read appfs entry for %s", slug);
+        free(file_data);
+        free(exec_path);
+        return ESP_FAIL;
+    }
+
+    // Write to install directory
+    FILE* fd = fastopen(exec_path, "wb");
+    if (fd == NULL) {
+        ESP_LOGE(TAG, "Failed to open %s for writing", exec_path);
+        free(file_data);
+        free(exec_path);
+        return ESP_FAIL;
+    }
+
+    size_t written = fwrite(file_data, 1, appfs_size, fd);
+    fastclose(fd);
+    free(file_data);
+
+    if (written != (size_t)appfs_size) {
+        ESP_LOGE(TAG, "Failed to write complete binary to %s", exec_path);
+        free(exec_path);
+        return ESP_FAIL;
+    }
+
+    ESP_LOGI(TAG, "Copied appfs binary for %s to %s", slug, exec_path);
+    free(exec_path);
+    return ESP_OK;
+}
+
+bool app_mgmt_can_uncache(const char* slug) {
+    // Check if the app has an install directory with metadata.
+    // Apps without one (dev/legacy, manually copied to appfs) cannot be
+    // uncached since removing from appfs would permanently lose the binary.
+    char path[256];
+    const char* base_paths[] = {"/int/apps", "/sd/apps"};
+    for (int i = 0; i < 2; i++) {
+        snprintf(path, sizeof(path), "%s/%s/metadata.json", base_paths[i], slug);
+        if (fs_utils_exists(path)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+esp_err_t app_mgmt_remove_from_appfs(const char* slug) {
+    if (!appfsExists(slug)) {
+        return ESP_OK;
+    }
+
+    // Ensure binary exists in install dir before removing from appfs (backward compat)
+    if (!app_mgmt_has_binary_in_install_dir(slug)) {
+        esp_err_t res = app_mgmt_copy_appfs_to_install_dir(slug);
+        if (res != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to back up appfs binary for %s, not removing", slug);
+            return res;
+        }
+    }
+
+    return appfsDeleteFile(slug);
+}
+
+esp_err_t app_mgmt_ensure_in_appfs(const char* slug, const char* name, uint32_t revision, const char* firmware_path) {
+    if (appfsExists(slug)) {
+        return ESP_OK;
+    }
+
+    FILE* fd = fastopen(firmware_path, "rb");
+    if (fd == NULL) {
+        ESP_LOGE(TAG, "Failed to open firmware file %s", firmware_path);
+        return ESP_FAIL;
+    }
+    size_t file_size = fs_utils_get_file_size(fd);
+    fastclose(fd);
+
+    if (file_size == 0) {
+        ESP_LOGE(TAG, "Firmware file %s is empty", firmware_path);
+        return ESP_FAIL;
+    }
+
+    size_t rounded_size = (file_size + (SPI_FLASH_MMU_PAGE_SIZE - 1)) & (~(SPI_FLASH_MMU_PAGE_SIZE - 1));
+    if (appfsGetFreeMem() < rounded_size) {
+        ESP_LOGW(TAG, "Not enough space in AppFS for %s (need %u, have %u)", slug, rounded_size, appfsGetFreeMem());
+        return ESP_ERR_NO_MEM;
+    }
+
+    return app_mgmt_install_from_file(slug, name, revision, (char*)firmware_path);
+}
+
+// Comparison function for qsort — sort by timestamp ascending (oldest first)
+typedef struct {
+    char     slug[48];
+    uint32_t timestamp;
+} appfs_usage_entry_t;
+
+static int compare_usage_entries(const void* a, const void* b) {
+    const appfs_usage_entry_t* ea = (const appfs_usage_entry_t*)a;
+    const appfs_usage_entry_t* eb = (const appfs_usage_entry_t*)b;
+    if (ea->timestamp < eb->timestamp) return -1;
+    if (ea->timestamp > eb->timestamp) return 1;
+    return 0;
+}
+
+esp_err_t app_mgmt_appfs_evict_lru(size_t needed_bytes) {
+    // Collect appfs entries that have a backup in the install directory.
+    // Apps without install dirs (dev/legacy apps only in appfs) are never auto-evicted
+    // since removing them would permanently lose the binary.
+    appfs_usage_entry_t entries[128];
+    size_t              count = 0;
+
+    appfs_handle_t appfs_fd = appfsNextEntry(APPFS_INVALID_FD);
+    while (appfs_fd != APPFS_INVALID_FD && count < 128) {
+        const char* slug = NULL;
+        appfsEntryInfoExt(appfs_fd, &slug, NULL, NULL, NULL);
+        if (slug != NULL && app_mgmt_can_uncache(slug)) {
+            strncpy(entries[count].slug, slug, sizeof(entries[count].slug) - 1);
+            entries[count].slug[sizeof(entries[count].slug) - 1] = '\0';
+
+            uint32_t ts = 0;
+            app_usage_get_last_used(slug, &ts);
+            entries[count].timestamp = ts;
+            count++;
+        }
+        appfs_fd = appfsNextEntry(appfs_fd);
+    }
+
+    if (count == 0) {
+        ESP_LOGW(TAG, "No appfs entries to evict");
+        return ESP_ERR_NO_MEM;
+    }
+
+    // Sort by timestamp ascending (oldest first)
+    qsort(entries, count, sizeof(appfs_usage_entry_t), compare_usage_entries);
+
+    // Evict entries until we have enough space
+    for (size_t i = 0; i < count; i++) {
+        if (appfsGetFreeMem() >= needed_bytes) {
+            return ESP_OK;
+        }
+        ESP_LOGI(TAG, "Evicting %s from AppFS (last used: %u)", entries[i].slug, entries[i].timestamp);
+        app_mgmt_remove_from_appfs(entries[i].slug);
+    }
+
+    if (appfsGetFreeMem() >= needed_bytes) {
+        return ESP_OK;
+    }
+
+    ESP_LOGW(TAG, "Could not free enough AppFS space (need %u, have %u)", needed_bytes, appfsGetFreeMem());
+    return ESP_ERR_NO_MEM;
+}
+
+// --- App move between storage locations ---
+
+static uint64_t get_directory_size(const char* path) {
+    struct stat st;
+    if (stat(path, &st) != 0) {
+        return 0;
+    }
+
+    if (!S_ISDIR(st.st_mode)) {
+        return st.st_size;
+    }
+
+    DIR* dir = opendir(path);
+    if (dir == NULL) {
+        return 0;
+    }
+
+    uint64_t       total = 0;
+    struct dirent* entry;
+    while ((entry = readdir(dir)) != NULL) {
+        if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) {
+            continue;
+        }
+
+        size_t full_len  = strlen(path) + strlen(entry->d_name) + 2;
+        char*  full_path = malloc(full_len);
+        if (full_path == NULL) {
+            break;
+        }
+        snprintf(full_path, full_len, "%s/%s", path, entry->d_name);
+        total += get_directory_size(full_path);
+        free(full_path);
+    }
+
+    closedir(dir);
+    return total;
+}
+
+esp_err_t app_mgmt_move(const char* slug, app_mgmt_location_t from, app_mgmt_location_t to) {
+    const char* src_base = app_mgmt_location_to_path(from);
+    const char* dst_base = app_mgmt_location_to_path(to);
+    if (src_base == NULL || dst_base == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    char src_path[256] = {0};
+    char dst_path[256] = {0};
+    snprintf(src_path, sizeof(src_path), "%s/%s", src_base, slug);
+    snprintf(dst_path, sizeof(dst_path), "%s/%s", dst_base, slug);
+
+    if (!fs_utils_exists(src_path)) {
+        ESP_LOGE(TAG, "Source app directory does not exist: %s", src_path);
+        return ESP_ERR_NOT_FOUND;
+    }
+
+    // Check free space on target filesystem
+    uint64_t dir_size = get_directory_size(src_path);
+    if (dir_size == 0) {
+        ESP_LOGE(TAG, "Failed to calculate directory size for %s", src_path);
+        return ESP_FAIL;
+    }
+
+    // Determine target mount point for free space check
+    const char* mount_point = (to == APP_MGMT_LOCATION_SD) ? "/sd" : "/int";
+    uint64_t    total_bytes = 0;
+    uint64_t    free_bytes  = 0;
+    esp_err_t   res         = esp_vfs_fat_info(mount_point, &total_bytes, &free_bytes);
+    if (res != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to get filesystem info for %s", mount_point);
+        return res;
+    }
+
+    if (free_bytes < dir_size) {
+        ESP_LOGW(TAG, "Not enough space on %s (need %llu, have %llu)", mount_point, dir_size, free_bytes);
+        return ESP_ERR_NO_MEM;
+    }
+
+    // Create base apps directory on target if needed
+    if (!fs_utils_exists(dst_base)) {
+        if (mkdir(dst_base, 0777) != 0) {
+            ESP_LOGE(TAG, "Failed to create apps directory: %s", dst_base);
+            return ESP_FAIL;
+        }
+    }
+
+    // Remove destination if it already exists
+    if (fs_utils_exists(dst_path)) {
+        fs_utils_remove(dst_path);
+    }
+
+    // Copy directory recursively
+    res = fs_utils_copy_recursive(src_path, dst_path);
+    if (res != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to copy app from %s to %s", src_path, dst_path);
+        // Clean up partial copy
+        if (fs_utils_exists(dst_path)) {
+            fs_utils_remove(dst_path);
+        }
+        return res;
+    }
+
+    // Remove source directory
+    res = fs_utils_remove(src_path);
+    if (res != ESP_OK) {
+        ESP_LOGW(TAG, "App copied but failed to remove source at %s", src_path);
+    }
+
+    ESP_LOGI(TAG, "Moved app %s from %s to %s", slug, src_base, dst_base);
+    return ESP_OK;
+}
+
+bool app_mgmt_can_move(const char* slug, app_mgmt_location_t from, app_mgmt_location_t to) {
+    const char* src_base = app_mgmt_location_to_path(from);
+    const char* dst_base = app_mgmt_location_to_path(to);
+    if (src_base == NULL || dst_base == NULL) {
+        return false;
+    }
+
+    char src_path[256] = {0};
+    snprintf(src_path, sizeof(src_path), "%s/%s", src_base, slug);
+    if (!fs_utils_exists(src_path)) {
+        return false;
+    }
+
+    uint64_t dir_size = get_directory_size(src_path);
+    if (dir_size == 0) {
+        return false;
+    }
+
+    const char* mount_point = (to == APP_MGMT_LOCATION_SD) ? "/sd" : "/int";
+    uint64_t    total_bytes = 0;
+    uint64_t    free_bytes  = 0;
+    if (esp_vfs_fat_info(mount_point, &total_bytes, &free_bytes) != ESP_OK) {
+        return false;
+    }
+
+    return free_bytes >= dir_size;
 }

--- a/main/app_management.h
+++ b/main/app_management.h
@@ -21,6 +21,8 @@ bool      app_mgmt_can_uncache(const char* slug);
 esp_err_t app_mgmt_copy_appfs_to_install_dir(const char* slug);
 esp_err_t app_mgmt_remove_from_appfs(const char* slug);
 esp_err_t app_mgmt_ensure_in_appfs(const char* slug, const char* name, uint32_t revision, const char* firmware_path);
+esp_err_t app_mgmt_cache_to_appfs(const char* slug, const char* name, uint32_t revision, const char* firmware_path);
 esp_err_t app_mgmt_appfs_evict_lru(size_t needed_bytes);
+char*     app_mgmt_find_firmware_path(const char* slug);
 esp_err_t app_mgmt_move(const char* slug, app_mgmt_location_t from, app_mgmt_location_t to);
 bool      app_mgmt_can_move(const char* slug, app_mgmt_location_t from, app_mgmt_location_t to);

--- a/main/app_management.h
+++ b/main/app_management.h
@@ -14,3 +14,13 @@ esp_err_t app_mgmt_install(const char* repository_url, const char* slug, app_mgm
                            download_callback_t download_callback);
 esp_err_t app_mgmt_uninstall(const char* slug, app_mgmt_location_t location);
 esp_err_t app_mgmt_install_from_file(const char* slug, const char* name, uint32_t revision, char* firmware_path);
+
+// AppFS cache management
+bool      app_mgmt_has_binary_in_install_dir(const char* slug);
+bool      app_mgmt_can_uncache(const char* slug);
+esp_err_t app_mgmt_copy_appfs_to_install_dir(const char* slug);
+esp_err_t app_mgmt_remove_from_appfs(const char* slug);
+esp_err_t app_mgmt_ensure_in_appfs(const char* slug, const char* name, uint32_t revision, const char* firmware_path);
+esp_err_t app_mgmt_appfs_evict_lru(size_t needed_bytes);
+esp_err_t app_mgmt_move(const char* slug, app_mgmt_location_t from, app_mgmt_location_t to);
+bool      app_mgmt_can_move(const char* slug, app_mgmt_location_t from, app_mgmt_location_t to);

--- a/main/app_management.h
+++ b/main/app_management.h
@@ -5,6 +5,8 @@
 #include "esp_err.h"
 #include "http_download.h"
 
+#define MAX_NUM_APPS 128
+
 typedef enum {
     APP_MGMT_LOCATION_INTERNAL = 0,
     APP_MGMT_LOCATION_SD,

--- a/main/app_metadata_parser.c
+++ b/main/app_metadata_parser.c
@@ -3,6 +3,7 @@
 #include <stddef.h>
 #include <stdio.h>
 #include <string.h>
+#include <sys/stat.h>
 #include "bsp/device.h"
 #include "cJSON.h"
 #include "esp_log.h"
@@ -129,7 +130,7 @@ bool get_executable_revision(const char* path, const char* slug, uint32_t* out_r
     return result;
 }
 
-app_t* create_app(const char* path, const char* slug, bool sdcard) {
+app_t* create_app(const char* path, const char* slug) {
     app_t* app = calloc(1, sizeof(app_t));
     app->path  = strdup(path);
     app->slug  = strdup(slug);
@@ -297,24 +298,22 @@ app_t* create_app(const char* path, const char* slug, bool sdcard) {
             if (filename_obj && (filename_obj->valuestring != NULL)) {
                 app->executable_filename = strdup(filename_obj->valuestring);
 
-                if (app->executable_type == EXECUTABLE_TYPE_APPFS && sdcard) {
-                    // Check for SD card executable
-                    app->executable_on_sd_revision = app->executable_revision;
-                    app->executable_on_sd_filename = strdup(app->executable_filename);
-
-                    printf("Check\r\n");
-
+                if (app->executable_type == EXECUTABLE_TYPE_APPFS) {
+                    // Check for executable binary in install directory
                     size_t length = snprintf(NULL, 0, "%s/%s/%s", path, slug, app->executable_filename);
                     if (length > 0) {
-                        app->executable_on_sd_filename = malloc(length + 1);
-                        if (app->executable_on_sd_filename) {
-                            snprintf(app->executable_on_sd_filename, length + 1, "%s/%s/%s", path, slug,
-                                     app->executable_filename);
-                            if (access(app->executable_on_sd_filename, F_OK) == 0) {
-                                printf("Found!!!!\r\n");
-                                app->executable_on_sd_available = true;
+                        char* fs_path = malloc(length + 1);
+                        if (fs_path) {
+                            snprintf(fs_path, length + 1, "%s/%s/%s", path, slug, app->executable_filename);
+                            struct stat fs_stat;
+                            if (stat(fs_path, &fs_stat) == 0) {
+                                free(app->executable_on_fs_filename);
+                                app->executable_on_fs_filename  = fs_path;
+                                app->executable_on_fs_revision  = app->executable_revision;
+                                app->executable_on_fs_filesize  = (int)fs_stat.st_size;
+                                app->executable_on_fs_available = true;
                             } else {
-                                printf("Not found (%s)!!!\r\n", app->executable_on_sd_filename);
+                                free(fs_path);
                             }
                         }
                     }
@@ -367,12 +366,12 @@ void free_app(app_t* app) {
         pax_buf_destroy(app->icon);
         free(app->icon);
     }
-    if (app->executable_on_sd_filename != NULL) free(app->executable_on_sd_filename);
+    if (app->executable_on_fs_filename != NULL) free(app->executable_on_fs_filename);
     free(app);
 }
 
 size_t create_list_of_apps_from_directory(app_t** out_list, size_t list_size, const char* path, app_t** full_list,
-                                          size_t full_list_size, bool sdcard) {
+                                          size_t full_list_size) {
     DIR* dir = opendir(path);
     if (dir == NULL) {
         return 0;
@@ -390,18 +389,28 @@ size_t create_list_of_apps_from_directory(app_t** out_list, size_t list_size, co
                     strcmp(full_list[i]->slug, entry->d_name) == 0) {
                     already_in_list = true;
 
-                    // Add SD card executable info if applicable
-                    if (sdcard && get_executable_revision(path, entry->d_name, &full_list[i]->executable_on_sd_revision,
-                                                          &full_list[i]->executable_on_sd_filename)) {
-                        if (access(full_list[i]->executable_on_sd_filename, F_OK) == 0) {
-                            full_list[i]->executable_on_sd_available = true;
+                    // Update filesystem executable info (SD overrides internal due to scan order)
+                    {
+                        uint32_t rev       = 0;
+                        char*    exec_path = NULL;
+                        if (get_executable_revision(path, entry->d_name, &rev, &exec_path)) {
+                            struct stat fs_stat;
+                            if (exec_path != NULL && stat(exec_path, &fs_stat) == 0) {
+                                free(full_list[i]->executable_on_fs_filename);
+                                full_list[i]->executable_on_fs_filename  = exec_path;
+                                full_list[i]->executable_on_fs_revision  = rev;
+                                full_list[i]->executable_on_fs_filesize  = (int)fs_stat.st_size;
+                                full_list[i]->executable_on_fs_available = true;
+                            } else {
+                                free(exec_path);
+                            }
                         }
                     }
                     break;
                 }
             }
             if (!already_in_list) {
-                app_t* app = create_app(path, entry->d_name, sdcard);
+                app_t* app = create_app(path, entry->d_name);
                 if (app != NULL && count < list_size) {
                     out_list[count++] = app;
                 }
@@ -458,10 +467,8 @@ size_t create_list_of_apps_from_other_appfs_entries(app_t** out_list, size_t lis
 size_t create_list_of_apps(app_t** out_list, size_t list_size) {
     size_t count = 0;
 
-    count += create_list_of_apps_from_directory(&out_list[count], list_size - count, "/int/apps", out_list, list_size,
-                                                false);
-    count +=
-        create_list_of_apps_from_directory(&out_list[count], list_size - count, "/sd/apps", out_list, list_size, true);
+    count += create_list_of_apps_from_directory(&out_list[count], list_size - count, "/int/apps", out_list, list_size);
+    count += create_list_of_apps_from_directory(&out_list[count], list_size - count, "/sd/apps", out_list, list_size);
     count += create_list_of_apps_from_other_appfs_entries(&out_list[count], list_size - count, out_list, list_size);
     return count;
 }

--- a/main/app_metadata_parser.c
+++ b/main/app_metadata_parser.c
@@ -45,16 +45,12 @@ bool get_executable_revision(const char* path, const char* slug, uint32_t* out_r
     printf("Finding executable revision for app %s in %s\n", slug, path);
     bool result = false;
 
-    app_t* app = calloc(1, sizeof(app_t));
-    app->path  = strdup(path);
-    app->slug  = strdup(slug);
-
     char path_buffer[256] = {0};
     snprintf(path_buffer, sizeof(path_buffer), "%s/%s/metadata.json", path, slug);
     FILE* fd = fastopen(path_buffer, "r");
     if (fd == NULL) {
         ESP_LOGE(TAG, "Failed to open metadata file %s", path_buffer);
-        return app;
+        return false;
     }
 
     char* json_data = (char*)load_file_to_ram(fd);
@@ -62,14 +58,14 @@ bool get_executable_revision(const char* path, const char* slug, uint32_t* out_r
 
     if (json_data == NULL) {
         ESP_LOGE(TAG, "Failed to read from metadata file %s", path_buffer);
-        return app;
+        return false;
     }
 
     cJSON* root = cJSON_Parse(json_data);
     if (root == NULL) {
         free(json_data);
         ESP_LOGE(TAG, "Failed to parse metadata file %s", path_buffer);
-        return app;
+        return false;
     }
 
     char device_name[32] = {0};
@@ -102,25 +98,21 @@ bool get_executable_revision(const char* path, const char* slug, uint32_t* out_r
     }
 
     if (matched_executable != NULL) {
-        // Parse application
         cJSON* type_obj = cJSON_GetObjectItem(matched_executable, "type");
         if (type_obj && (type_obj->valuestring != NULL)) {
             if (strcmp(type_obj->valuestring, "appfs") == 0) {
-                app->executable_type     = EXECUTABLE_TYPE_APPFS;
-                app->executable_appfs_fd = find_appfs_handle_for_slug(app->slug);
-
                 cJSON* revision_obj = cJSON_GetObjectItem(matched_executable, "revision");
                 if (revision_obj) {
                     *out_revision = revision_obj->valueint;
                     if (out_executable != NULL) {
-                        cJSON* executable_obj = cJSON_GetObjectItem(matched_executable, "executable");
-                        if (executable_obj != NULL && cJSON_IsString(executable_obj)) {
-                            size_t length = snprintf(NULL, 0, "%s/%s/%s", path, slug, executable_obj->valuestring);
+                        cJSON* exec_name_obj = cJSON_GetObjectItem(matched_executable, "executable");
+                        if (exec_name_obj != NULL && cJSON_IsString(exec_name_obj)) {
+                            size_t length = snprintf(NULL, 0, "%s/%s/%s", path, slug, exec_name_obj->valuestring);
                             if (length > 0) {
                                 *out_executable = malloc(length + 1);
                                 if (*out_executable) {
                                     snprintf(*out_executable, length + 1, "%s/%s/%s", path, slug,
-                                             executable_obj->valuestring);
+                                             exec_name_obj->valuestring);
                                     result = true;
                                 }
                             }

--- a/main/app_metadata_parser.h
+++ b/main/app_metadata_parser.h
@@ -34,18 +34,19 @@ typedef struct {
     char*             executable_interpreter_slug;
     appfs_handle_t    executable_appfs_fd;
 
-    bool     executable_on_sd_available;
-    uint32_t executable_on_sd_revision;
-    char*    executable_on_sd_filename;
+    bool     executable_on_fs_available;
+    uint32_t executable_on_fs_revision;
+    int      executable_on_fs_filesize;
+    char*    executable_on_fs_filename;
 } app_t;
 
 appfs_handle_t find_appfs_handle_for_slug(const char* search_slug);
 bool           get_executable_revision(const char* path, const char* slug, uint32_t* out_revision, char** out_executable);
-app_t*         create_app(const char* path, const char* slug, bool sdcard);
+app_t*         create_app(const char* path, const char* slug);
 void           free_app(app_t* app);
 
 size_t create_list_of_apps_from_directory(app_t** out_list, size_t list_size, const char* path, app_t** full_list,
-                                          size_t full_list_size, bool sdcard);
+                                          size_t full_list_size);
 size_t create_list_of_apps_from_other_appfs_entries(app_t** out_list, size_t list_size, app_t** full_list,
                                                     size_t full_list_size);
 size_t create_list_of_apps(app_t** out_list, size_t list_size);

--- a/main/app_metadata_parser.h
+++ b/main/app_metadata_parser.h
@@ -40,6 +40,7 @@ typedef struct {
 } app_t;
 
 appfs_handle_t find_appfs_handle_for_slug(const char* search_slug);
+bool           get_executable_revision(const char* path, const char* slug, uint32_t* out_revision, char** out_executable);
 app_t*         create_app(const char* path, const char* slug, bool sdcard);
 void           free_app(app_t* app);
 

--- a/main/app_usage.c
+++ b/main/app_usage.c
@@ -1,0 +1,70 @@
+#include "app_usage.h"
+#include <stdint.h>
+#include "esp_err.h"
+#include "nvs.h"
+
+static const char* APP_USAGE_NAMESPACE = "app_usage";
+
+esp_err_t app_usage_get_last_used(const char* slug, uint32_t* out_timestamp) {
+    if (slug == NULL || out_timestamp == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    nvs_handle_t nvs_handle;
+    esp_err_t    res = nvs_open(APP_USAGE_NAMESPACE, NVS_READONLY, &nvs_handle);
+    if (res != ESP_OK) {
+        *out_timestamp = 0;
+        return res;
+    }
+    uint32_t value;
+    res = nvs_get_u32(nvs_handle, slug, &value);
+    if (res != ESP_OK) {
+        *out_timestamp = 0;
+        nvs_close(nvs_handle);
+        return res;
+    }
+    nvs_close(nvs_handle);
+    *out_timestamp = value;
+    return res;
+}
+
+esp_err_t app_usage_set_last_used(const char* slug, uint32_t timestamp) {
+    if (slug == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    nvs_handle_t nvs_handle;
+    esp_err_t    res = nvs_open(APP_USAGE_NAMESPACE, NVS_READWRITE, &nvs_handle);
+    if (res != ESP_OK) {
+        return res;
+    }
+    res = nvs_set_u32(nvs_handle, slug, timestamp);
+    if (res != ESP_OK) {
+        nvs_close(nvs_handle);
+        return res;
+    }
+    res = nvs_commit(nvs_handle);
+    nvs_close(nvs_handle);
+    return res;
+}
+
+esp_err_t app_usage_remove_last_used(const char* slug) {
+    if (slug == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    nvs_handle_t nvs_handle;
+    esp_err_t    res = nvs_open(APP_USAGE_NAMESPACE, NVS_READWRITE, &nvs_handle);
+    if (res != ESP_OK) {
+        return res;
+    }
+    res = nvs_erase_key(nvs_handle, slug);
+    if (res == ESP_ERR_NVS_NOT_FOUND) {
+        nvs_close(nvs_handle);
+        return ESP_OK;
+    }
+    if (res != ESP_OK) {
+        nvs_close(nvs_handle);
+        return res;
+    }
+    res = nvs_commit(nvs_handle);
+    nvs_close(nvs_handle);
+    return res;
+}

--- a/main/app_usage.h
+++ b/main/app_usage.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <stdint.h>
+#include "esp_err.h"
+
+esp_err_t app_usage_get_last_used(const char* slug, uint32_t* out_timestamp);
+esp_err_t app_usage_set_last_used(const char* slug, uint32_t timestamp);
+esp_err_t app_usage_remove_last_used(const char* slug);

--- a/main/appfs_settings.c
+++ b/main/appfs_settings.c
@@ -1,0 +1,43 @@
+#include "appfs_settings.h"
+#include <stdint.h>
+#include "esp_err.h"
+#include "nvs.h"
+
+static const char* APPFS_NAMESPACE = "appfs";
+
+esp_err_t appfs_settings_get_auto_cleanup(uint8_t* out_value) {
+    if (out_value == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    nvs_handle_t nvs_handle;
+    esp_err_t    res = nvs_open(APPFS_NAMESPACE, NVS_READONLY, &nvs_handle);
+    if (res != ESP_OK) {
+        *out_value = DEFAULT_APPFS_AUTO_CLEANUP;
+        return res;
+    }
+    uint8_t value;
+    res = nvs_get_u8(nvs_handle, "auto_cleanup", &value);
+    nvs_close(nvs_handle);
+    if (res != ESP_OK) {
+        *out_value = DEFAULT_APPFS_AUTO_CLEANUP;
+        return res;
+    }
+    *out_value = value;
+    return ESP_OK;
+}
+
+esp_err_t appfs_settings_set_auto_cleanup(uint8_t value) {
+    nvs_handle_t nvs_handle;
+    esp_err_t    res = nvs_open(APPFS_NAMESPACE, NVS_READWRITE, &nvs_handle);
+    if (res != ESP_OK) {
+        return res;
+    }
+    res = nvs_set_u8(nvs_handle, "auto_cleanup", value);
+    if (res != ESP_OK) {
+        nvs_close(nvs_handle);
+        return res;
+    }
+    res = nvs_commit(nvs_handle);
+    nvs_close(nvs_handle);
+    return res;
+}

--- a/main/appfs_settings.c
+++ b/main/appfs_settings.c
@@ -41,3 +41,40 @@ esp_err_t appfs_settings_set_auto_cleanup(uint8_t value) {
     nvs_close(nvs_handle);
     return res;
 }
+
+esp_err_t appfs_settings_get_mismatch_reinstall(uint8_t* out_value) {
+    if (out_value == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    nvs_handle_t nvs_handle;
+    esp_err_t    res = nvs_open(APPFS_NAMESPACE, NVS_READONLY, &nvs_handle);
+    if (res != ESP_OK) {
+        *out_value = DEFAULT_APPFS_MISMATCH_REINSTALL;
+        return res;
+    }
+    uint8_t value;
+    res = nvs_get_u8(nvs_handle, "mismatch_reinst", &value);
+    nvs_close(nvs_handle);
+    if (res != ESP_OK) {
+        *out_value = DEFAULT_APPFS_MISMATCH_REINSTALL;
+        return res;
+    }
+    *out_value = value;
+    return ESP_OK;
+}
+
+esp_err_t appfs_settings_set_mismatch_reinstall(uint8_t value) {
+    nvs_handle_t nvs_handle;
+    esp_err_t    res = nvs_open(APPFS_NAMESPACE, NVS_READWRITE, &nvs_handle);
+    if (res != ESP_OK) {
+        return res;
+    }
+    res = nvs_set_u8(nvs_handle, "mismatch_reinst", value);
+    if (res != ESP_OK) {
+        nvs_close(nvs_handle);
+        return res;
+    }
+    res = nvs_commit(nvs_handle);
+    nvs_close(nvs_handle);
+    return res;
+}

--- a/main/appfs_settings.h
+++ b/main/appfs_settings.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <stdint.h>
+#include "esp_err.h"
+
+#define DEFAULT_APPFS_AUTO_CLEANUP 0
+
+esp_err_t appfs_settings_get_auto_cleanup(uint8_t* out_value);
+esp_err_t appfs_settings_set_auto_cleanup(uint8_t value);

--- a/main/appfs_settings.h
+++ b/main/appfs_settings.h
@@ -3,7 +3,10 @@
 #include <stdint.h>
 #include "esp_err.h"
 
-#define DEFAULT_APPFS_AUTO_CLEANUP 1
+#define DEFAULT_APPFS_AUTO_CLEANUP        1
+#define DEFAULT_APPFS_MISMATCH_REINSTALL  0
 
 esp_err_t appfs_settings_get_auto_cleanup(uint8_t* out_value);
 esp_err_t appfs_settings_set_auto_cleanup(uint8_t value);
+esp_err_t appfs_settings_get_mismatch_reinstall(uint8_t* out_value);
+esp_err_t appfs_settings_set_mismatch_reinstall(uint8_t value);

--- a/main/appfs_settings.h
+++ b/main/appfs_settings.h
@@ -3,7 +3,7 @@
 #include <stdint.h>
 #include "esp_err.h"
 
-#define DEFAULT_APPFS_AUTO_CLEANUP 0
+#define DEFAULT_APPFS_AUTO_CLEANUP 1
 
 esp_err_t appfs_settings_get_auto_cleanup(uint8_t* out_value);
 esp_err_t appfs_settings_set_auto_cleanup(uint8_t value);

--- a/main/filesystem_utils.c
+++ b/main/filesystem_utils.c
@@ -182,6 +182,42 @@ esp_err_t fs_utils_copy_recursive(const char* src, const char* dst) {
     return result;
 }
 
+uint64_t fs_utils_get_directory_size(const char* path) {
+    struct stat st;
+    if (stat(path, &st) != 0) {
+        return 0;
+    }
+
+    if (!S_ISDIR(st.st_mode)) {
+        return st.st_size;
+    }
+
+    DIR* dir = opendir(path);
+    if (dir == NULL) {
+        return 0;
+    }
+
+    uint64_t       total = 0;
+    struct dirent* entry;
+    while ((entry = readdir(dir)) != NULL) {
+        if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) {
+            continue;
+        }
+
+        size_t full_len  = strlen(path) + strlen(entry->d_name) + 2;
+        char*  full_path = malloc(full_len);
+        if (full_path == NULL) {
+            break;
+        }
+        snprintf(full_path, full_len, "%s/%s", path, entry->d_name);
+        total += fs_utils_get_directory_size(full_path);
+        free(full_path);
+    }
+
+    closedir(dir);
+    return total;
+}
+
 size_t fs_utils_get_file_size(FILE* fd) {
     fseek(fd, 0, SEEK_END);
     size_t fsize = ftell(fd);

--- a/main/filesystem_utils.c
+++ b/main/filesystem_utils.c
@@ -1,9 +1,11 @@
 #include "filesystem_utils.h"
 #include <stdbool.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/unistd.h>
 #include "esp_err.h"
+#include "fastopen.h"
 #include "sys/dirent.h"
 
 bool fs_utils_exists(const char* path) {
@@ -86,6 +88,98 @@ esp_err_t fs_utils_remove(const char* path) {
     closedir(dir);
 
     return failed ? ESP_FAIL : ESP_OK;
+}
+
+static esp_err_t copy_single_file(const char* src, const char* dst) {
+    FILE* f_src = fastopen(src, "rb");
+    if (f_src == NULL) {
+        return ESP_FAIL;
+    }
+
+    FILE* f_dst = fastopen(dst, "wb");
+    if (f_dst == NULL) {
+        fastclose(f_src);
+        return ESP_FAIL;
+    }
+
+    uint8_t* buf = malloc(4096);
+    if (buf == NULL) {
+        fastclose(f_src);
+        fastclose(f_dst);
+        return ESP_ERR_NO_MEM;
+    }
+
+    esp_err_t result = ESP_OK;
+    size_t    bytes_read;
+    while ((bytes_read = fread(buf, 1, 4096, f_src)) > 0) {
+        if (fwrite(buf, 1, bytes_read, f_dst) != bytes_read) {
+            result = ESP_FAIL;
+            break;
+        }
+    }
+
+    free(buf);
+    fastclose(f_src);
+    fastclose(f_dst);
+    return result;
+}
+
+esp_err_t fs_utils_copy_recursive(const char* src, const char* dst) {
+    struct stat stat_src;
+    if (stat(src, &stat_src) != 0) {
+        return ESP_ERR_NOT_FOUND;
+    }
+
+    // If source is a file, copy it directly
+    if (!S_ISDIR(stat_src.st_mode)) {
+        return copy_single_file(src, dst);
+    }
+
+    // Create destination directory
+    if (mkdir(dst, 0777) != 0) {
+        // Check if it already exists
+        if (!fs_utils_is_directory(dst)) {
+            return ESP_FAIL;
+        }
+    }
+
+    DIR* dir = opendir(src);
+    if (dir == NULL) {
+        return ESP_FAIL;
+    }
+
+    struct dirent* entry;
+    esp_err_t      result = ESP_OK;
+    while ((entry = readdir(dir)) != NULL) {
+        if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) {
+            continue;
+        }
+
+        size_t src_len = strlen(src) + strlen(entry->d_name) + 2;
+        size_t dst_len = strlen(dst) + strlen(entry->d_name) + 2;
+        char*  src_path = malloc(src_len);
+        char*  dst_path = malloc(dst_len);
+        if (src_path == NULL || dst_path == NULL) {
+            free(src_path);
+            free(dst_path);
+            result = ESP_ERR_NO_MEM;
+            break;
+        }
+
+        snprintf(src_path, src_len, "%s/%s", src, entry->d_name);
+        snprintf(dst_path, dst_len, "%s/%s", dst, entry->d_name);
+
+        result = fs_utils_copy_recursive(src_path, dst_path);
+        free(src_path);
+        free(dst_path);
+
+        if (result != ESP_OK) {
+            break;
+        }
+    }
+
+    closedir(dir);
+    return result;
 }
 
 size_t fs_utils_get_file_size(FILE* fd) {

--- a/main/filesystem_utils.h
+++ b/main/filesystem_utils.h
@@ -7,5 +7,6 @@ bool      fs_utils_exists(const char* path);
 bool      fs_utils_is_directory(const char* path);
 bool      fs_utils_is_file(const char* path);
 esp_err_t fs_utils_remove(const char* path);
+esp_err_t fs_utils_copy_recursive(const char* src, const char* dst);
 size_t    fs_utils_get_file_size(FILE* fd);
 uint8_t*  fs_utils_load_file_to_ram(FILE* fd);

--- a/main/filesystem_utils.h
+++ b/main/filesystem_utils.h
@@ -8,5 +8,6 @@ bool      fs_utils_is_directory(const char* path);
 bool      fs_utils_is_file(const char* path);
 esp_err_t fs_utils_remove(const char* path);
 esp_err_t fs_utils_copy_recursive(const char* src, const char* dst);
+uint64_t  fs_utils_get_directory_size(const char* path);
 size_t    fs_utils_get_file_size(FILE* fd);
 uint8_t*  fs_utils_load_file_to_ram(FILE* fd);

--- a/main/menu/app_inspect.c
+++ b/main/menu/app_inspect.c
@@ -245,10 +245,7 @@ bool menu_app_inspect(pax_buf_t* buffer, gui_theme_t* theme, app_t* app) {
                                     busy_dialog(get_icon(ICON_APPS), "Moving",
                                                 "Moving app...", true);
                                     esp_err_t res = app_mgmt_move(app->slug, from, to);
-                                    if (res == ESP_OK) {
-                                        message_dialog(get_icon(ICON_INFO), "Success",
-                                                       "App moved successfully", "OK");
-                                    } else if (res == ESP_ERR_NO_MEM) {
+                                    if (res == ESP_ERR_NO_MEM) {
                                         char err_msg[128];
                                         snprintf(err_msg, sizeof(err_msg),
                                                  "Not enough space on %s", to_name);
@@ -274,10 +271,7 @@ bool menu_app_inspect(pax_buf_t* buffer, gui_theme_t* theme, app_t* app) {
                                         busy_dialog(get_icon(ICON_APPS), "Removing",
                                                     "Removing from AppFS...", true);
                                         esp_err_t res = app_mgmt_remove_from_appfs(app->slug);
-                                        if (res == ESP_OK) {
-                                            message_dialog(get_icon(ICON_INFO), "Success",
-                                                           "Removed from AppFS", "OK");
-                                        } else {
+                                        if (res != ESP_OK) {
                                             message_dialog(get_icon(ICON_ERROR), "Failed",
                                                            "Failed to remove from AppFS", "OK");
                                         }
@@ -300,10 +294,7 @@ bool menu_app_inspect(pax_buf_t* buffer, gui_theme_t* theme, app_t* app) {
                                             message_dialog(get_icon(ICON_ERROR), "No space",
                                                            "Not enough space in AppFS.\n"
                                                            "Remove cached apps (F4).", "OK");
-                                        } else if (res == ESP_OK) {
-                                            message_dialog(get_icon(ICON_INFO), "Success",
-                                                           "App cached in AppFS", "OK");
-                                        } else {
+                                        } else if (res != ESP_OK) {
                                             message_dialog(get_icon(ICON_ERROR), "Failed",
                                                            "Failed to cache app", "OK");
                                         }
@@ -319,10 +310,7 @@ bool menu_app_inspect(pax_buf_t* buffer, gui_theme_t* theme, app_t* app) {
                                 if (msg_ret == MSG_DIALOG_RETURN_OK) {
                                     esp_err_t res_int = app_mgmt_uninstall(app->slug, APP_MGMT_LOCATION_INTERNAL);
                                     esp_err_t res_sd  = app_mgmt_uninstall(app->slug, APP_MGMT_LOCATION_SD);
-                                    if (res_int == ESP_OK || res_sd == ESP_OK) {
-                                        message_dialog(get_icon(ICON_INFO), "Success", "App removed successfully",
-                                                       "OK");
-                                    } else {
+                                    if (res_int != ESP_OK && res_sd != ESP_OK) {
                                         message_dialog(get_icon(ICON_ERROR), "Failed", "Failed to remove app", "OK");
                                     }
                                     return true;

--- a/main/menu/app_inspect.c
+++ b/main/menu/app_inspect.c
@@ -2,6 +2,7 @@
 #include "app_inspect.h"
 #include <string.h>
 #include "app_management.h"
+#include "app_metadata_parser.h"
 #include "appfs.h"
 #include "bsp/input.h"
 #include "common/display.h"
@@ -166,6 +167,12 @@ static void render(pax_buf_t* buffer, gui_theme_t* theme, pax_vec2_t position, b
                           position.y0 + (TEXT_SIZE + 2) * (line++), text_buffer);
         }
 
+        if (app->executable_type == EXECUTABLE_TYPE_SCRIPT && app->executable_interpreter_slug) {
+            snprintf(text_buffer, sizeof(text_buffer), "Interpreter: %s", app->executable_interpreter_slug);
+            pax_draw_text(buffer, theme->palette.color_foreground, TEXT_FONT, TEXT_SIZE, position.x0,
+                          position.y0 + (TEXT_SIZE + 2) * (line++), text_buffer);
+        }
+
         // Install location
         if (app_is_on_sd(app)) {
             snprintf(text_buffer, sizeof(text_buffer), "Location: SD Card");
@@ -261,6 +268,7 @@ bool menu_app_inspect(pax_buf_t* buffer, gui_theme_t* theme, app_t* app) {
                                 break;
                             }
                             case BSP_INPUT_NAVIGATION_KEY_F4: {
+                                if (app->executable_type != EXECUTABLE_TYPE_APPFS) break;
                                 if (app->executable_appfs_fd != APPFS_INVALID_FD &&
                                     app_mgmt_can_uncache(app->slug)) {
                                     // Cached → uncache

--- a/main/menu/app_inspect.c
+++ b/main/menu/app_inspect.c
@@ -1,15 +1,10 @@
 
 #include "app_inspect.h"
 #include <string.h>
-#include <time.h>
 #include "app_management.h"
-#include "app_metadata_parser.h"
 #include "appfs.h"
-#include "appfs_settings.h"
 #include "bsp/input.h"
 #include "common/display.h"
-#include "fastopen.h"
-#include "filesystem_utils.h"
 #include "gui_element_icontext.h"
 #include "gui_style.h"
 #include "icons.h"
@@ -60,15 +55,19 @@
 #define TEXT_FONT    pax_font_sky_mono
 #define TEXT_SIZE    18
 #elif defined(CONFIG_BSP_TARGET_MCH2022) || defined(CONFIG_BSP_TARGET_KAMI)
-#define FOOTER_LEFT_CACHE   ((gui_element_icontext_t[]){{NULL, "\xf0\x9f\x85\xb1 Back"}}), 1
-#define FOOTER_LEFT_UNCACHE ((gui_element_icontext_t[]){{NULL, "\xf0\x9f\x85\xb1 Back"}}), 1
-#define FOOTER_LEFT_PLAIN   ((gui_element_icontext_t[]){{NULL, "\xf0\x9f\x85\xb1 Back"}}), 1
+#define FOOTER_LEFT_CACHE_MOVE   ((gui_element_icontext_t[]){{NULL, "\xf0\x9f\x85\xb1 Back"}}), 1
+#define FOOTER_LEFT_UNCACHE_MOVE ((gui_element_icontext_t[]){{NULL, "\xf0\x9f\x85\xb1 Back"}}), 1
+#define FOOTER_LEFT_CACHE        ((gui_element_icontext_t[]){{NULL, "\xf0\x9f\x85\xb1 Back"}}), 1
+#define FOOTER_LEFT_UNCACHE      ((gui_element_icontext_t[]){{NULL, "\xf0\x9f\x85\xb1 Back"}}), 1
+#define FOOTER_LEFT_PLAIN        ((gui_element_icontext_t[]){{NULL, "\xf0\x9f\x85\xb1 Back"}}), 1
 #define TEXT_FONT    pax_font_sky_mono
 #define TEXT_SIZE    9
 #else
-#define FOOTER_LEFT_CACHE   NULL, 0
-#define FOOTER_LEFT_UNCACHE NULL, 0
-#define FOOTER_LEFT_PLAIN   NULL, 0
+#define FOOTER_LEFT_CACHE_MOVE   NULL, 0
+#define FOOTER_LEFT_UNCACHE_MOVE NULL, 0
+#define FOOTER_LEFT_CACHE        NULL, 0
+#define FOOTER_LEFT_UNCACHE      NULL, 0
+#define FOOTER_LEFT_PLAIN        NULL, 0
 #define TEXT_FONT    pax_font_sky_mono
 #define TEXT_SIZE    9
 #endif
@@ -287,61 +286,27 @@ bool menu_app_inspect(pax_buf_t* buffer, gui_theme_t* theme, app_t* app) {
                                 } else if (app->executable_type == EXECUTABLE_TYPE_APPFS &&
                                            app->executable_appfs_fd == APPFS_INVALID_FD) {
                                     // Not cached → cache
-                                    const char* base_paths[] = {"/int/apps", "/sd/apps"};
-                                    char*       firmware_path = NULL;
-                                    for (int i = 0; i < 2; i++) {
-                                        uint32_t rev = 0;
-                                        if (get_executable_revision(base_paths[i], app->slug, &rev,
-                                                                     &firmware_path)) {
-                                            if (firmware_path != NULL && fs_utils_exists(firmware_path)) {
-                                                break;
-                                            }
-                                            free(firmware_path);
-                                            firmware_path = NULL;
-                                        }
-                                    }
+                                    char* firmware_path = app_mgmt_find_firmware_path(app->slug);
                                     if (firmware_path == NULL) {
                                         message_dialog(get_icon(ICON_ERROR), "Error",
                                                        "App binary not found", "OK");
                                     } else {
                                         busy_dialog(get_icon(ICON_APPS), "Caching",
                                                     "Copying app to AppFS...", true);
-                                        esp_err_t res = app_mgmt_ensure_in_appfs(
+                                        esp_err_t res = app_mgmt_cache_to_appfs(
                                             app->slug, app->name, app->executable_revision, firmware_path);
+                                        free(firmware_path);
                                         if (res == ESP_ERR_NO_MEM) {
-                                            uint8_t auto_cleanup = 0;
-                                            appfs_settings_get_auto_cleanup(&auto_cleanup);
-                                            if (auto_cleanup) {
-                                                busy_dialog(get_icon(ICON_APPS), "Caching",
-                                                            "Freeing up space...", true);
-                                                FILE* f = fastopen(firmware_path, "rb");
-                                                if (f != NULL) {
-                                                    size_t fsize = fs_utils_get_file_size(f);
-                                                    fastclose(f);
-                                                    size_t rounded = (fsize + (SPI_FLASH_MMU_PAGE_SIZE - 1)) &
-                                                                     (~(SPI_FLASH_MMU_PAGE_SIZE - 1));
-                                                    app_mgmt_appfs_evict_lru(rounded);
-                                                    busy_dialog(get_icon(ICON_APPS), "Caching",
-                                                                "Copying app to AppFS...", true);
-                                                    res = app_mgmt_ensure_in_appfs(
-                                                        app->slug, app->name, app->executable_revision,
-                                                        firmware_path);
-                                                }
-                                            }
-                                            if (res == ESP_ERR_NO_MEM) {
-                                                message_dialog(get_icon(ICON_ERROR), "No space",
-                                                               "Not enough space in AppFS.\n"
-                                                               "Remove cached apps (F4).", "OK");
-                                            }
-                                        }
-                                        if (res == ESP_OK) {
+                                            message_dialog(get_icon(ICON_ERROR), "No space",
+                                                           "Not enough space in AppFS.\n"
+                                                           "Remove cached apps (F4).", "OK");
+                                        } else if (res == ESP_OK) {
                                             message_dialog(get_icon(ICON_INFO), "Success",
                                                            "App cached in AppFS", "OK");
-                                        } else if (res != ESP_ERR_NO_MEM) {
+                                        } else {
                                             message_dialog(get_icon(ICON_ERROR), "Failed",
                                                            "Failed to cache app", "OK");
                                         }
-                                        free(firmware_path);
                                     }
                                     return true;  // Trigger app list refresh
                                 }

--- a/main/menu/app_inspect.c
+++ b/main/menu/app_inspect.c
@@ -1,9 +1,15 @@
 
 #include "app_inspect.h"
 #include <string.h>
+#include <time.h>
 #include "app_management.h"
+#include "app_metadata_parser.h"
+#include "appfs.h"
+#include "appfs_settings.h"
 #include "bsp/input.h"
 #include "common/display.h"
+#include "fastopen.h"
+#include "filesystem_utils.h"
 #include "gui_element_icontext.h"
 #include "gui_style.h"
 #include "icons.h"
@@ -15,37 +21,118 @@
 #include "pax_types.h"
 
 #if defined(CONFIG_BSP_TARGET_TANMATSU) || defined(CONFIG_BSP_TARGET_KONSOOL)
-#define FOOTER_LEFT                                                  \
-    ((gui_element_icontext_t[]){{get_icon(ICON_ESC), "/"},           \
-                                {get_icon(ICON_F1), "Back"},         \
-                                {get_icon(ICON_F2), "Start"},        \
-                                {get_icon(ICON_F5), "Delete App"}}), \
+#define FOOTER_LEFT_CACHE_MOVE                                           \
+    ((gui_element_icontext_t[]){{get_icon(ICON_ESC), "/"},               \
+                                {get_icon(ICON_F1), "Back"},             \
+                                {get_icon(ICON_F2), "Start"},            \
+                                {get_icon(ICON_F3), "Move"},             \
+                                {get_icon(ICON_F4), "Cache"},            \
+                                {get_icon(ICON_F5), "Delete App"}}),     \
+        6
+#define FOOTER_LEFT_UNCACHE_MOVE                                         \
+    ((gui_element_icontext_t[]){{get_icon(ICON_ESC), "/"},               \
+                                {get_icon(ICON_F1), "Back"},             \
+                                {get_icon(ICON_F2), "Start"},            \
+                                {get_icon(ICON_F3), "Move"},             \
+                                {get_icon(ICON_F4), "Uncache"},          \
+                                {get_icon(ICON_F5), "Delete App"}}),     \
+        6
+#define FOOTER_LEFT_CACHE                                                \
+    ((gui_element_icontext_t[]){{get_icon(ICON_ESC), "/"},               \
+                                {get_icon(ICON_F1), "Back"},             \
+                                {get_icon(ICON_F2), "Start"},            \
+                                {get_icon(ICON_F4), "Cache"},            \
+                                {get_icon(ICON_F5), "Delete App"}}),     \
+        5
+#define FOOTER_LEFT_UNCACHE                                              \
+    ((gui_element_icontext_t[]){{get_icon(ICON_ESC), "/"},               \
+                                {get_icon(ICON_F1), "Back"},             \
+                                {get_icon(ICON_F2), "Start"},            \
+                                {get_icon(ICON_F4), "Uncache"},          \
+                                {get_icon(ICON_F5), "Delete App"}}),     \
+        5
+#define FOOTER_LEFT_PLAIN                                                \
+    ((gui_element_icontext_t[]){{get_icon(ICON_ESC), "/"},               \
+                                {get_icon(ICON_F1), "Back"},             \
+                                {get_icon(ICON_F2), "Start"},            \
+                                {get_icon(ICON_F5), "Delete App"}}),     \
         4
-#define FOOTER_RIGHT NULL, 0
 #define TEXT_FONT    pax_font_sky_mono
 #define TEXT_SIZE    18
 #elif defined(CONFIG_BSP_TARGET_MCH2022) || defined(CONFIG_BSP_TARGET_KAMI)
-#define FOOTER_LEFT  ((gui_element_icontext_t[]){{NULL, "🅱 Back"}}), 1
-#define FOOTER_RIGHT NULL, 0
+#define FOOTER_LEFT_CACHE   ((gui_element_icontext_t[]){{NULL, "\xf0\x9f\x85\xb1 Back"}}), 1
+#define FOOTER_LEFT_UNCACHE ((gui_element_icontext_t[]){{NULL, "\xf0\x9f\x85\xb1 Back"}}), 1
+#define FOOTER_LEFT_PLAIN   ((gui_element_icontext_t[]){{NULL, "\xf0\x9f\x85\xb1 Back"}}), 1
 #define TEXT_FONT    pax_font_sky_mono
 #define TEXT_SIZE    9
 #else
-#define FOOTER_LEFT  NULL, 0
-#define FOOTER_RIGHT NULL, 0
+#define FOOTER_LEFT_CACHE   NULL, 0
+#define FOOTER_LEFT_UNCACHE NULL, 0
+#define FOOTER_LEFT_PLAIN   NULL, 0
 #define TEXT_FONT    pax_font_sky_mono
 #define TEXT_SIZE    9
 #endif
+#define FOOTER_RIGHT NULL, 0
 
-static void render(pax_buf_t* buffer, gui_theme_t* theme, pax_vec2_t position, bool partial, bool icons, app_t* app) {
+static bool app_is_on_sd(app_t* app) {
+    return app->path != NULL && strncmp(app->path, "/sd", 3) == 0;
+}
+
+static bool app_is_on_internal(app_t* app) {
+    return app->path != NULL && strncmp(app->path, "/int", 4) == 0;
+}
+
+static bool app_has_install_dir(app_t* app) {
+    return app_is_on_sd(app) || app_is_on_internal(app);
+}
+
+static bool check_move_possible(app_t* app) {
+    if (!app_has_install_dir(app)) {
+        return false;
+    }
+    app_mgmt_location_t from = app_is_on_sd(app) ? APP_MGMT_LOCATION_SD : APP_MGMT_LOCATION_INTERNAL;
+    app_mgmt_location_t to   = app_is_on_sd(app) ? APP_MGMT_LOCATION_INTERNAL : APP_MGMT_LOCATION_SD;
+    return app_mgmt_can_move(app->slug, from, to);
+}
+
+static void render(pax_buf_t* buffer, gui_theme_t* theme, pax_vec2_t position, bool partial, bool icons, app_t* app,
+                   bool can_move) {
 
     char text_buffer[256];
     int  line = 0;
 
+    // Determine which footer to show based on cache state and move capability
+    bool in_appfs    = (app->executable_type == EXECUTABLE_TYPE_APPFS &&
+                        app->executable_appfs_fd != APPFS_INVALID_FD);
+    bool can_uncache = app_mgmt_can_uncache(app->slug);
+
     if (!partial || icons) {
         snprintf(text_buffer, sizeof(text_buffer), "App Info: %s", app->name);
-        render_base_screen_statusbar(buffer, theme, !partial, !partial || icons, !partial,
-                                     ((gui_element_icontext_t[]){{get_icon(ICON_INFO), text_buffer}}), 1, FOOTER_LEFT,
-                                     FOOTER_RIGHT);
+        if (in_appfs && can_uncache) {
+            if (can_move) {
+                render_base_screen_statusbar(buffer, theme, !partial, !partial || icons, !partial,
+                                             ((gui_element_icontext_t[]){{get_icon(ICON_INFO), text_buffer}}), 1,
+                                             FOOTER_LEFT_UNCACHE_MOVE, FOOTER_RIGHT);
+            } else {
+                render_base_screen_statusbar(buffer, theme, !partial, !partial || icons, !partial,
+                                             ((gui_element_icontext_t[]){{get_icon(ICON_INFO), text_buffer}}), 1,
+                                             FOOTER_LEFT_UNCACHE, FOOTER_RIGHT);
+            }
+        } else if (!in_appfs && app->executable_type == EXECUTABLE_TYPE_APPFS) {
+            if (can_move) {
+                render_base_screen_statusbar(buffer, theme, !partial, !partial || icons, !partial,
+                                             ((gui_element_icontext_t[]){{get_icon(ICON_INFO), text_buffer}}), 1,
+                                             FOOTER_LEFT_CACHE_MOVE, FOOTER_RIGHT);
+            } else {
+                render_base_screen_statusbar(buffer, theme, !partial, !partial || icons, !partial,
+                                             ((gui_element_icontext_t[]){{get_icon(ICON_INFO), text_buffer}}), 1,
+                                             FOOTER_LEFT_CACHE, FOOTER_RIGHT);
+            }
+        } else {
+            render_base_screen_statusbar(buffer, theme, !partial, !partial || icons, !partial,
+                                         ((gui_element_icontext_t[]){{get_icon(ICON_INFO), text_buffer}}), 1,
+                                         FOOTER_LEFT_PLAIN, FOOTER_RIGHT);
+        }
     }
 
     if (!partial) {
@@ -79,6 +166,24 @@ static void render(pax_buf_t* buffer, gui_theme_t* theme, pax_vec2_t position, b
             pax_draw_text(buffer, theme->palette.color_foreground, TEXT_FONT, TEXT_SIZE, position.x0,
                           position.y0 + (TEXT_SIZE + 2) * (line++), text_buffer);
         }
+
+        // Install location
+        if (app_is_on_sd(app)) {
+            snprintf(text_buffer, sizeof(text_buffer), "Location: SD Card");
+        } else if (app_is_on_internal(app)) {
+            snprintf(text_buffer, sizeof(text_buffer), "Location: Internal");
+        } else {
+            snprintf(text_buffer, sizeof(text_buffer), "Location: AppFS only");
+        }
+        pax_draw_text(buffer, theme->palette.color_foreground, TEXT_FONT, TEXT_SIZE, position.x0,
+                      position.y0 + (TEXT_SIZE + 2) * (line++), text_buffer);
+
+        // AppFS free space info
+        size_t free_kb  = appfsGetFreeMem() / 1024;
+        size_t total_kb = appfsGetTotalMem() / 1024;
+        snprintf(text_buffer, sizeof(text_buffer), "AppFS: %u / %u KB free", free_kb, total_kb);
+        pax_draw_text(buffer, theme->palette.color_foreground, TEXT_FONT, TEXT_SIZE, position.x0,
+                      position.y0 + (TEXT_SIZE + 2) * (line++), text_buffer);
     }
 
     display_blit_buffer(buffer);
@@ -98,7 +203,9 @@ bool menu_app_inspect(pax_buf_t* buffer, gui_theme_t* theme, app_t* app) {
         .y1 = pax_buf_get_height(buffer) - footer_height - theme->menu.vertical_margin - theme->menu.vertical_padding,
     };
 
-    render(buffer, theme, position, false, false, app);
+    bool can_move = check_move_possible(app);
+
+    render(buffer, theme, position, false, false, app, can_move);
 
     while (1) {
         bsp_input_event_t event;
@@ -113,8 +220,134 @@ bool menu_app_inspect(pax_buf_t* buffer, gui_theme_t* theme, app_t* app) {
                                 return false;
                             case BSP_INPUT_NAVIGATION_KEY_F2:
                                 execute_app(buffer, theme, position, app);
-                                render(buffer, theme, position, false, false, app);
+                                render(buffer, theme, position, false, false, app, can_move);
                                 break;
+                            case BSP_INPUT_NAVIGATION_KEY_F3: {
+                                if (!app_has_install_dir(app)) {
+                                    break;
+                                }
+                                app_mgmt_location_t from, to;
+                                const char*         to_name;
+                                if (app_is_on_sd(app)) {
+                                    from    = APP_MGMT_LOCATION_SD;
+                                    to      = APP_MGMT_LOCATION_INTERNAL;
+                                    to_name = "Internal storage";
+                                } else {
+                                    from    = APP_MGMT_LOCATION_INTERNAL;
+                                    to      = APP_MGMT_LOCATION_SD;
+                                    to_name = "SD Card";
+                                }
+                                char confirm_msg[128];
+                                snprintf(confirm_msg, sizeof(confirm_msg),
+                                         "Move app to %s?", to_name);
+                                message_dialog_return_type_t msg_ret = adv_dialog_yes_no(
+                                    get_icon(ICON_HELP), "Move App", confirm_msg);
+                                if (msg_ret == MSG_DIALOG_RETURN_OK) {
+                                    busy_dialog(get_icon(ICON_APPS), "Moving",
+                                                "Moving app...", true);
+                                    esp_err_t res = app_mgmt_move(app->slug, from, to);
+                                    if (res == ESP_OK) {
+                                        message_dialog(get_icon(ICON_INFO), "Success",
+                                                       "App moved successfully", "OK");
+                                    } else if (res == ESP_ERR_NO_MEM) {
+                                        char err_msg[128];
+                                        snprintf(err_msg, sizeof(err_msg),
+                                                 "Not enough space on %s", to_name);
+                                        message_dialog(get_icon(ICON_ERROR), "No space",
+                                                       err_msg, "OK");
+                                    } else {
+                                        message_dialog(get_icon(ICON_ERROR), "Failed",
+                                                       "Failed to move app", "OK");
+                                    }
+                                    return true;  // Trigger app list refresh
+                                }
+                                render(buffer, theme, position, false, false, app, can_move);
+                                break;
+                            }
+                            case BSP_INPUT_NAVIGATION_KEY_F4: {
+                                if (app->executable_appfs_fd != APPFS_INVALID_FD &&
+                                    app_mgmt_can_uncache(app->slug)) {
+                                    // Cached → uncache
+                                    message_dialog_return_type_t msg_ret = adv_dialog_yes_no(
+                                        get_icon(ICON_HELP), "Remove from cache",
+                                        "Remove app binary from AppFS cache?");
+                                    if (msg_ret == MSG_DIALOG_RETURN_OK) {
+                                        busy_dialog(get_icon(ICON_APPS), "Removing",
+                                                    "Removing from AppFS...", true);
+                                        esp_err_t res = app_mgmt_remove_from_appfs(app->slug);
+                                        if (res == ESP_OK) {
+                                            message_dialog(get_icon(ICON_INFO), "Success",
+                                                           "Removed from AppFS", "OK");
+                                        } else {
+                                            message_dialog(get_icon(ICON_ERROR), "Failed",
+                                                           "Failed to remove from AppFS", "OK");
+                                        }
+                                        return true;  // Trigger app list refresh
+                                    }
+                                } else if (app->executable_type == EXECUTABLE_TYPE_APPFS &&
+                                           app->executable_appfs_fd == APPFS_INVALID_FD) {
+                                    // Not cached → cache
+                                    const char* base_paths[] = {"/int/apps", "/sd/apps"};
+                                    char*       firmware_path = NULL;
+                                    for (int i = 0; i < 2; i++) {
+                                        uint32_t rev = 0;
+                                        if (get_executable_revision(base_paths[i], app->slug, &rev,
+                                                                     &firmware_path)) {
+                                            if (firmware_path != NULL && fs_utils_exists(firmware_path)) {
+                                                break;
+                                            }
+                                            free(firmware_path);
+                                            firmware_path = NULL;
+                                        }
+                                    }
+                                    if (firmware_path == NULL) {
+                                        message_dialog(get_icon(ICON_ERROR), "Error",
+                                                       "App binary not found", "OK");
+                                    } else {
+                                        busy_dialog(get_icon(ICON_APPS), "Caching",
+                                                    "Copying app to AppFS...", true);
+                                        esp_err_t res = app_mgmt_ensure_in_appfs(
+                                            app->slug, app->name, app->executable_revision, firmware_path);
+                                        if (res == ESP_ERR_NO_MEM) {
+                                            uint8_t auto_cleanup = 0;
+                                            appfs_settings_get_auto_cleanup(&auto_cleanup);
+                                            if (auto_cleanup) {
+                                                busy_dialog(get_icon(ICON_APPS), "Caching",
+                                                            "Freeing up space...", true);
+                                                FILE* f = fastopen(firmware_path, "rb");
+                                                if (f != NULL) {
+                                                    size_t fsize = fs_utils_get_file_size(f);
+                                                    fastclose(f);
+                                                    size_t rounded = (fsize + (SPI_FLASH_MMU_PAGE_SIZE - 1)) &
+                                                                     (~(SPI_FLASH_MMU_PAGE_SIZE - 1));
+                                                    app_mgmt_appfs_evict_lru(rounded);
+                                                    busy_dialog(get_icon(ICON_APPS), "Caching",
+                                                                "Copying app to AppFS...", true);
+                                                    res = app_mgmt_ensure_in_appfs(
+                                                        app->slug, app->name, app->executable_revision,
+                                                        firmware_path);
+                                                }
+                                            }
+                                            if (res == ESP_ERR_NO_MEM) {
+                                                message_dialog(get_icon(ICON_ERROR), "No space",
+                                                               "Not enough space in AppFS.\n"
+                                                               "Remove cached apps (F4).", "OK");
+                                            }
+                                        }
+                                        if (res == ESP_OK) {
+                                            message_dialog(get_icon(ICON_INFO), "Success",
+                                                           "App cached in AppFS", "OK");
+                                        } else if (res != ESP_ERR_NO_MEM) {
+                                            message_dialog(get_icon(ICON_ERROR), "Failed",
+                                                           "Failed to cache app", "OK");
+                                        }
+                                        free(firmware_path);
+                                    }
+                                    return true;  // Trigger app list refresh
+                                }
+                                render(buffer, theme, position, false, false, app, can_move);
+                                break;
+                            }
                             case BSP_INPUT_NAVIGATION_KEY_F5: {
                                 message_dialog_return_type_t msg_ret = adv_dialog_yes_no(
                                     get_icon(ICON_HELP), "Delete App", "Do you really want to delete the app?");
@@ -129,7 +362,7 @@ bool menu_app_inspect(pax_buf_t* buffer, gui_theme_t* theme, app_t* app) {
                                     }
                                     return true;
                                 }
-                                render(buffer, theme, position, false, false, app);
+                                render(buffer, theme, position, false, false, app, can_move);
                                 break;
                             }
                             default:
@@ -142,7 +375,7 @@ bool menu_app_inspect(pax_buf_t* buffer, gui_theme_t* theme, app_t* app) {
                     break;
             }
         } else {
-            render(buffer, theme, position, false, false, app);
+            render(buffer, theme, position, false, false, app, can_move);
         }
     }
 }

--- a/main/menu/apps.c
+++ b/main/menu/apps.c
@@ -4,10 +4,14 @@
 #include <stdio.h>
 #include <string.h>
 #include <sys/syslimits.h>
+#include <time.h>
 #include "app_inspect.h"
 #include "app_management.h"
 #include "app_metadata_parser.h"
+#include "app_usage.h"
 #include "appfs.h"
+#include "appfs_settings.h"
+#include "fastopen.h"
 #if CONFIG_IDF_TARGET_ESP32P4
 #include "badge_elf.h"
 #endif
@@ -34,12 +38,68 @@ static const char* TAG = "apps";
 static void populate_menu(menu_t* menu, app_t** apps, size_t app_count) {
     for (size_t i = 0; i < app_count; i++) {
         if (apps[i] != NULL && apps[i]->slug != NULL && apps[i]->name != NULL) {
-            menu_insert_item_icon(menu, apps[i]->name, NULL, (void*)apps[i], -1, apps[i]->icon);
+            char label[128];
+            bool in_appfs = (apps[i]->executable_type == EXECUTABLE_TYPE_APPFS &&
+                             apps[i]->executable_appfs_fd != APPFS_INVALID_FD);
+            snprintf(label, sizeof(label), "%s %s", in_appfs ? "[C]" : "   ", apps[i]->name);
+            menu_insert_item_icon(menu, label, NULL, (void*)apps[i], -1, apps[i]->icon);
         }
     }
 }
 
 extern bool wifi_stack_get_task_done(void);
+
+// Helper: ensure interpreter is loaded into AppFS for script apps.
+// Returns the appfs handle on success, APPFS_INVALID_FD on failure.
+static appfs_handle_t ensure_interpreter_in_appfs(const char* interpreter_slug) {
+    appfs_handle_t fd = find_appfs_handle_for_slug(interpreter_slug);
+    if (fd != APPFS_INVALID_FD) {
+        return fd;
+    }
+
+    // Interpreter not in appfs — try to find its binary in install dirs and load it
+    const char* base_paths[] = {"/int/apps", "/sd/apps"};
+    for (int i = 0; i < 2; i++) {
+        uint32_t revision  = 0;
+        char*    exec_path = NULL;
+        if (get_executable_revision(base_paths[i], interpreter_slug, &revision, &exec_path)) {
+            if (exec_path != NULL && fs_utils_exists(exec_path)) {
+                busy_dialog(get_icon(ICON_APPS), "Loading", "Loading interpreter to AppFS...", true);
+                esp_err_t res = app_mgmt_ensure_in_appfs(interpreter_slug, interpreter_slug, revision, exec_path);
+                if (res == ESP_ERR_NO_MEM) {
+                    uint8_t auto_cleanup = 0;
+                    appfs_settings_get_auto_cleanup(&auto_cleanup);
+                    if (auto_cleanup) {
+                        busy_dialog(get_icon(ICON_APPS), "Loading", "Freeing up space...", true);
+                        FILE* f = fastopen(exec_path, "rb");
+                        if (f != NULL) {
+                            size_t file_size    = fs_utils_get_file_size(f);
+                            fastclose(f);
+                            size_t rounded_size = (file_size + (SPI_FLASH_MMU_PAGE_SIZE - 1)) &
+                                                  (~(SPI_FLASH_MMU_PAGE_SIZE - 1));
+                            app_mgmt_appfs_evict_lru(rounded_size);
+                            busy_dialog(get_icon(ICON_APPS), "Loading", "Loading interpreter to AppFS...", true);
+                            res = app_mgmt_ensure_in_appfs(interpreter_slug, interpreter_slug, revision, exec_path);
+                        }
+                    }
+                    if (res == ESP_ERR_NO_MEM) {
+                        message_dialog(get_icon(ICON_ERROR), "No space",
+                                       "Not enough space in AppFS for interpreter.\nRemove cached apps (F4).", "OK");
+                    }
+                }
+                free(exec_path);
+                if (res == ESP_OK) {
+                    return find_appfs_handle_for_slug(interpreter_slug);
+                }
+                return APPFS_INVALID_FD;
+            }
+            free(exec_path);
+        }
+    }
+
+    message_dialog(get_icon(ICON_ERROR), "Error", "Interpreter binary not found", "OK");
+    return APPFS_INVALID_FD;
+}
 
 void execute_app(pax_buf_t* buffer, gui_theme_t* theme, pax_vec2_t position, app_t* app) {
 
@@ -47,6 +107,9 @@ void execute_app(pax_buf_t* buffer, gui_theme_t* theme, pax_vec2_t position, app
         message_dialog(get_icon(ICON_ERROR), "Error", "No app selected", "OK");
         return;
     }
+
+    // Record last-used time for LRU eviction
+    app_usage_set_last_used(app->slug, (uint32_t)time(NULL));
 
     render_base_screen_statusbar(buffer, theme, true, true, true,
                                  ((gui_element_icontext_t[]){{get_icon(ICON_APPS), "Apps"}}), 1, NULL, 0, NULL, 0);
@@ -110,10 +173,9 @@ void execute_app(pax_buf_t* buffer, gui_theme_t* theme, pax_vec2_t position, app
                 return;
             }
 
-            // TODO: properly parse app entry for interpreter, for now just assume it's in AppFS
-            appfs_handle_t interpreter_fd = find_appfs_handle_for_slug(app->executable_interpreter_slug);
+            // Ensure interpreter is in AppFS (load on-demand if needed)
+            appfs_handle_t interpreter_fd = ensure_interpreter_in_appfs(app->executable_interpreter_slug);
             if (interpreter_fd == APPFS_INVALID_FD) {
-                message_dialog(get_icon(ICON_ERROR), "Error", "Interpreter not found in AppFS", "OK");
                 return;
             }
 
@@ -153,74 +215,161 @@ void execute_app(pax_buf_t* buffer, gui_theme_t* theme, pax_vec2_t position, app
 }
 
 #if defined(CONFIG_BSP_TARGET_TANMATSU) || defined(CONFIG_BSP_TARGET_KONSOOL)
-#define FOOTER_LEFT                                              \
-    ((gui_element_icontext_t[]){{get_icon(ICON_ESC), "/"},       \
-                                {get_icon(ICON_F1), "Back"},     \
-                                {get_icon(ICON_F2), "Details"},  \
-                                {get_icon(ICON_F5), "Remove"}}), \
-        4
-#define FOOTER_LEFT_UPDATE                                       \
-    ((gui_element_icontext_t[]){{get_icon(ICON_ESC), "/"},       \
-                                {get_icon(ICON_F1), "Back"},     \
-                                {get_icon(ICON_F2), "Details"},  \
-                                {get_icon(ICON_F5), "Remove"},   \
-                                {get_icon(ICON_F6), "Update"}}), \
+#define FOOTER_LEFT_CACHE                                          \
+    ((gui_element_icontext_t[]){{get_icon(ICON_ESC), "/"},         \
+                                {get_icon(ICON_F1), "Back"},       \
+                                {get_icon(ICON_F2), "Details"},    \
+                                {get_icon(ICON_F4), "Cache"},      \
+                                {get_icon(ICON_F5), "Remove"}}),   \
         5
-#define FOOTER_RIGHT             ((gui_element_icontext_t[]){{NULL, "↑ / ↓ | ⏎ Start app"}}), 1
-#define FOOTER_RIGHT_INSTALL     ((gui_element_icontext_t[]){{NULL, "↑ / ↓ | ⏎ Install app"}}), 1
-#define FOOTER_RIGHT_UNAVAILABLE ((gui_element_icontext_t[]){{NULL, "↑ / ↓ | ⏎ (Unavailable)"}}), 1
+#define FOOTER_LEFT_UNCACHE                                        \
+    ((gui_element_icontext_t[]){{get_icon(ICON_ESC), "/"},         \
+                                {get_icon(ICON_F1), "Back"},       \
+                                {get_icon(ICON_F2), "Details"},    \
+                                {get_icon(ICON_F4), "Uncache"},    \
+                                {get_icon(ICON_F5), "Remove"}}),   \
+        5
+#define FOOTER_LEFT_UNCACHE_UPDATE                                 \
+    ((gui_element_icontext_t[]){{get_icon(ICON_ESC), "/"},         \
+                                {get_icon(ICON_F1), "Back"},       \
+                                {get_icon(ICON_F2), "Details"},    \
+                                {get_icon(ICON_F4), "Uncache"},    \
+                                {get_icon(ICON_F5), "Remove"},     \
+                                {get_icon(ICON_F6), "Update"}}),   \
+        6
+#define FOOTER_LEFT_PLAIN                                          \
+    ((gui_element_icontext_t[]){{get_icon(ICON_ESC), "/"},         \
+                                {get_icon(ICON_F1), "Back"},       \
+                                {get_icon(ICON_F2), "Details"},    \
+                                {get_icon(ICON_F5), "Remove"}}),   \
+        4
 #elif defined(CONFIG_BSP_TARGET_MCH2022) || defined(CONFIG_BSP_TARGET_KAMI)
-#define FOOTER_LEFT              NULL, 0
-#define FOOTER_LEFT_UPDATE       NULL, 0
-#define FOOTER_RIGHT             ((gui_element_icontext_t[]){{NULL, "🅼 Info 🅴 Remove 🅰 Start"}}), 1
-#define FOOTER_RIGHT_INSTALL     ((gui_element_icontext_t[]){{NULL, "🅼 Info 🅴 Remove 🅰 Install"}}), 1
-#define FOOTER_RIGHT_UNAVAILABLE ((gui_element_icontext_t[]){{NULL, "🅼 Info 🅴 Remove 🅰 (Unavailable)"}}), 1
+#define FOOTER_LEFT_CACHE          NULL, 0
+#define FOOTER_LEFT_UNCACHE        NULL, 0
+#define FOOTER_LEFT_UNCACHE_UPDATE NULL, 0
+#define FOOTER_LEFT_PLAIN          NULL, 0
 #else
-#define FOOTER_LEFT                                                                                \
-    ((gui_element_icontext_t[]){                                                                   \
-        {get_icon(ICON_ESC), "/"}, {NULL, "F1 Back"}, {NULL, "F2 Details"}, {NULL, "F5 Remove"}}), \
-        4
-#define FOOTER_LEFT_UPDATE                                 \
-    ((gui_element_icontext_t[]){{get_icon(ICON_ESC), "/"}, \
-                                {NULL, "F1 Back"},         \
-                                {NULL, "F2 Details"},      \
-                                {NULL, "F5 Remove"},       \
-                                {NULL, "F6 Update"}}),     \
+#define FOOTER_LEFT_CACHE                                          \
+    ((gui_element_icontext_t[]){{get_icon(ICON_ESC), "/"},         \
+                                {NULL, "F1 Back"},                 \
+                                {NULL, "F2 Details"},              \
+                                {NULL, "F4 Cache"},                \
+                                {NULL, "F5 Remove"}}),             \
         5
-#define FOOTER_RIGHT             ((gui_element_icontext_t[]){{NULL, "↑ / ↓ | ⏎ Start app"}}), 1
-#define FOOTER_RIGHT_INSTALL     ((gui_element_icontext_t[]){{NULL, "↑ / ↓ | ⏎ Install app"}}), 1
-#define FOOTER_RIGHT_UNAVAILABLE ((gui_element_icontext_t[]){{NULL, "↑ / ↓ | ⏎ (Unavailable)"}}), 1
+#define FOOTER_LEFT_UNCACHE                                        \
+    ((gui_element_icontext_t[]){{get_icon(ICON_ESC), "/"},         \
+                                {NULL, "F1 Back"},                 \
+                                {NULL, "F2 Details"},              \
+                                {NULL, "F4 Uncache"},              \
+                                {NULL, "F5 Remove"}}),             \
+        5
+#define FOOTER_LEFT_UNCACHE_UPDATE                                 \
+    ((gui_element_icontext_t[]){{get_icon(ICON_ESC), "/"},         \
+                                {NULL, "F1 Back"},                 \
+                                {NULL, "F2 Details"},              \
+                                {NULL, "F4 Uncache"},              \
+                                {NULL, "F5 Remove"},               \
+                                {NULL, "F6 Update"}}),             \
+        6
+#define FOOTER_LEFT_PLAIN                                          \
+    ((gui_element_icontext_t[]){{get_icon(ICON_ESC), "/"},         \
+                                {NULL, "F1 Back"},                 \
+                                {NULL, "F2 Details"},              \
+                                {NULL, "F5 Remove"}}),             \
+        4
 #endif
 
 typedef enum {
-    APP_MENU_FOOTER_TYPE_NORMAL = 0,
-    APP_MENU_FOOTER_TYPE_INSTALL,
-    APP_MENU_FOOTER_TYPE_UPDATE,
-    APP_MENU_FOOTER_TYPE_UNAVAILABLE,
+    APP_MENU_FOOTER_TYPE_NORMAL_CACHED = 0,  // In appfs, has install dir → F4 "Uncache"
+    APP_MENU_FOOTER_TYPE_NORMAL_UNCACHED,    // Not in appfs, has install dir → F4 "Cache"
+    APP_MENU_FOOTER_TYPE_NORMAL_PLAIN,       // In appfs, no install dir (dev/legacy) → no F4
+    APP_MENU_FOOTER_TYPE_UPDATE_CACHED,      // In appfs, update available → F4 "Uncache" + F6 "Update"
+    APP_MENU_FOOTER_TYPE_INSTALL,            // Binary on disk, not in appfs → F4 "Cache"
+    APP_MENU_FOOTER_TYPE_UNAVAILABLE,        // Nothing available → no F4
     APP_MENU_FOOTER_TYPE_COUNT,
 } app_menu_footer_type_t;
 
 static app_menu_footer_type_t previous_footer_type = APP_MENU_FOOTER_TYPE_COUNT;
 
+// Helper to find firmware path for an app (checks SD then internal install dir)
+// Returns malloc'd string or NULL. Caller must free.
+static char* find_firmware_path(app_t* app) {
+    if (app->executable_on_sd_available && app->executable_on_sd_filename != NULL) {
+        if (fs_utils_exists(app->executable_on_sd_filename)) {
+            return strdup(app->executable_on_sd_filename);
+        }
+    }
+    // Check internal install dir
+    const char* base_paths[] = {"/int/apps", "/sd/apps"};
+    for (int i = 0; i < 2; i++) {
+        uint32_t revision  = 0;
+        char*    exec_path = NULL;
+        if (get_executable_revision(base_paths[i], app->slug, &revision, &exec_path)) {
+            if (exec_path != NULL && fs_utils_exists(exec_path)) {
+                return exec_path;
+            }
+            free(exec_path);
+        }
+    }
+    return NULL;
+}
+
+// Helper to load an app into AppFS on-demand, with auto-cleanup support.
+// Returns ESP_OK on success, error otherwise. Shows dialogs.
+static esp_err_t load_app_to_appfs(app_t* app, const char* firmware_path) {
+    busy_dialog(get_icon(ICON_APPS), "Loading", "Copying app to AppFS...", true);
+    esp_err_t res = app_mgmt_ensure_in_appfs(app->slug, app->name, app->executable_revision, firmware_path);
+    if (res == ESP_ERR_NO_MEM) {
+        uint8_t auto_cleanup = 0;
+        appfs_settings_get_auto_cleanup(&auto_cleanup);
+        if (auto_cleanup) {
+            busy_dialog(get_icon(ICON_APPS), "Loading", "Freeing up space...", true);
+            // Calculate needed size
+            FILE* fd = fastopen(firmware_path, "rb");
+            if (fd != NULL) {
+                size_t file_size    = fs_utils_get_file_size(fd);
+                fastclose(fd);
+                size_t rounded_size = (file_size + (SPI_FLASH_MMU_PAGE_SIZE - 1)) & (~(SPI_FLASH_MMU_PAGE_SIZE - 1));
+                app_mgmt_appfs_evict_lru(rounded_size);
+                busy_dialog(get_icon(ICON_APPS), "Loading", "Copying app to AppFS...", true);
+                res = app_mgmt_ensure_in_appfs(app->slug, app->name, app->executable_revision, firmware_path);
+            }
+        }
+        if (res == ESP_ERR_NO_MEM) {
+            message_dialog(get_icon(ICON_ERROR), "No space",
+                           "Not enough space in AppFS.\nRemove cached apps (F4) to free space.", "OK");
+        }
+    }
+    if (res != ESP_OK && res != ESP_ERR_NO_MEM) {
+        message_dialog(get_icon(ICON_ERROR), "Failed", "Failed to load app to AppFS", "OK");
+    }
+    return res;
+}
+
 static void render(pax_buf_t* buffer, gui_theme_t* theme, menu_t* menu, pax_vec2_t position, bool partial, bool icons) {
     void*  arg = menu_get_callback_args(menu, menu_get_position(menu));
     app_t* app = (app_t*)arg;
 
-    app_menu_footer_type_t footer_type = APP_MENU_FOOTER_TYPE_NORMAL;
+    app_menu_footer_type_t footer_type = APP_MENU_FOOTER_TYPE_NORMAL_UNCACHED;
     if (app == NULL) {
         footer_type = APP_MENU_FOOTER_TYPE_UNAVAILABLE;
     } else {
         if (app->executable_type == EXECUTABLE_TYPE_APPFS) {
+            bool can_uncache = app_mgmt_can_uncache(app->slug);
             if (app->executable_appfs_fd == APPFS_INVALID_FD) {
-                if (app->executable_on_sd_available) {
+                if (app->executable_on_sd_available || app_mgmt_has_binary_in_install_dir(app->slug)) {
                     footer_type = APP_MENU_FOOTER_TYPE_INSTALL;
                 } else {
                     footer_type = APP_MENU_FOOTER_TYPE_UNAVAILABLE;
                 }
             } else {
-                // Check for updates
                 if (app->executable_on_sd_available && app->executable_on_sd_revision > app->executable_revision) {
-                    footer_type = APP_MENU_FOOTER_TYPE_UPDATE;
+                    footer_type = APP_MENU_FOOTER_TYPE_UPDATE_CACHED;
+                } else if (can_uncache) {
+                    footer_type = APP_MENU_FOOTER_TYPE_NORMAL_CACHED;
+                } else {
+                    // App only exists in appfs (dev/legacy), no cache toggle available
+                    footer_type = APP_MENU_FOOTER_TYPE_NORMAL_PLAIN;
                 }
             }
         }
@@ -232,26 +381,56 @@ static void render(pax_buf_t* buffer, gui_theme_t* theme, menu_t* menu, pax_vec2
     }
 
     if (!partial || icons) {
+        // Build dynamic footer right with AppFS free space
+        char footer_right_text[80];
+        size_t free_kb  = appfsGetFreeMem() / 1024;
+        size_t total_kb = appfsGetTotalMem() / 1024;
+
+        const char* action_text;
         switch (footer_type) {
-            case APP_MENU_FOOTER_TYPE_NORMAL:
+            case APP_MENU_FOOTER_TYPE_INSTALL:
+                action_text = "⏎ Cache app";
+                break;
+            case APP_MENU_FOOTER_TYPE_UNAVAILABLE:
+                action_text = "⏎ (Unavailable)";
+                break;
+            default:
+                action_text = "⏎ Start app";
+                break;
+        }
+        snprintf(footer_right_text, sizeof(footer_right_text), "AppFS: %u/%uKB | %s", free_kb, total_kb, action_text);
+        gui_element_icontext_t footer_right[] = {{NULL, footer_right_text}};
+
+        switch (footer_type) {
+            case APP_MENU_FOOTER_TYPE_NORMAL_CACHED:
                 render_base_screen_statusbar(buffer, theme, !partial, !partial || icons, !partial,
                                              ((gui_element_icontext_t[]){{get_icon(ICON_APPS), "Apps"}}), 1,
-                                             FOOTER_LEFT, FOOTER_RIGHT);
+                                             FOOTER_LEFT_UNCACHE, footer_right, 1);
+                break;
+            case APP_MENU_FOOTER_TYPE_NORMAL_UNCACHED:
+                render_base_screen_statusbar(buffer, theme, !partial, !partial || icons, !partial,
+                                             ((gui_element_icontext_t[]){{get_icon(ICON_APPS), "Apps"}}), 1,
+                                             FOOTER_LEFT_CACHE, footer_right, 1);
+                break;
+            case APP_MENU_FOOTER_TYPE_NORMAL_PLAIN:
+                render_base_screen_statusbar(buffer, theme, !partial, !partial || icons, !partial,
+                                             ((gui_element_icontext_t[]){{get_icon(ICON_APPS), "Apps"}}), 1,
+                                             FOOTER_LEFT_PLAIN, footer_right, 1);
                 break;
             case APP_MENU_FOOTER_TYPE_INSTALL:
                 render_base_screen_statusbar(buffer, theme, !partial, !partial || icons, !partial,
                                              ((gui_element_icontext_t[]){{get_icon(ICON_APPS), "Apps"}}), 1,
-                                             FOOTER_LEFT, FOOTER_RIGHT_INSTALL);
+                                             FOOTER_LEFT_CACHE, footer_right, 1);
                 break;
-            case APP_MENU_FOOTER_TYPE_UPDATE:
+            case APP_MENU_FOOTER_TYPE_UPDATE_CACHED:
                 render_base_screen_statusbar(buffer, theme, !partial, !partial || icons, !partial,
                                              ((gui_element_icontext_t[]){{get_icon(ICON_APPS), "Apps"}}), 1,
-                                             FOOTER_LEFT_UPDATE, FOOTER_RIGHT);
+                                             FOOTER_LEFT_UNCACHE_UPDATE, footer_right, 1);
                 break;
             case APP_MENU_FOOTER_TYPE_UNAVAILABLE:
                 render_base_screen_statusbar(buffer, theme, !partial, !partial || icons, !partial,
                                              ((gui_element_icontext_t[]){{get_icon(ICON_APPS), "Apps"}}), 1,
-                                             FOOTER_LEFT, FOOTER_RIGHT_UNAVAILABLE);
+                                             FOOTER_LEFT_PLAIN, footer_right, 1);
                 break;
             default:
                 break;
@@ -315,27 +494,69 @@ void menu_apps(pax_buf_t* buffer, gui_theme_t* theme) {
                                 case BSP_INPUT_NAVIGATION_KEY_JOYSTICK_PRESS: {
                                     void*  arg = menu_get_callback_args(&menu, menu_get_position(&menu));
                                     app_t* app = (app_t*)arg;
+                                    // On-demand AppFS loading for appfs-type apps
                                     if (app->executable_type == EXECUTABLE_TYPE_APPFS &&
-                                        app->executable_appfs_fd == APPFS_INVALID_FD &&
-                                        app->executable_on_sd_available) {
-                                        // Install from SD card
-                                        busy_dialog(get_icon(ICON_APPS), "Installing", "Installing application...",
-                                                    true);
-                                        esp_err_t res = app_mgmt_install_from_file(app->slug, app->name,
-                                                                                   app->executable_on_sd_revision,
-                                                                                   app->executable_on_sd_filename);
-                                        if (res == ESP_OK) {
-                                            message_dialog(get_icon(ICON_INFO), "Success", "App installed successfully",
-                                                           "OK");
+                                        app->executable_appfs_fd == APPFS_INVALID_FD) {
+                                        char* firmware_path = find_firmware_path(app);
+                                        if (firmware_path == NULL) {
+                                            message_dialog(get_icon(ICON_ERROR), "Error",
+                                                           "App binary not found", "OK");
+                                            render(buffer, theme, &menu, position, false, false);
+                                            break;
+                                        }
+                                        esp_err_t res = load_app_to_appfs(app, firmware_path);
+                                        free(firmware_path);
+                                        if (res != ESP_OK) {
+                                            refresh = true;
+                                            break;
+                                        }
+                                        app->executable_appfs_fd = find_appfs_handle_for_slug(app->slug);
+                                    }
+                                    execute_app(buffer, theme, position, app);
+                                    render(buffer, theme, &menu, position, false, false);
+                                    break;
+                                }
+                                case BSP_INPUT_NAVIGATION_KEY_F4: {
+                                    void*  arg = menu_get_callback_args(&menu, menu_get_position(&menu));
+                                    app_t* app = (app_t*)arg;
+                                    if (app->executable_appfs_fd != APPFS_INVALID_FD &&
+                                        app_mgmt_can_uncache(app->slug)) {
+                                        // Cached → uncache
+                                        message_dialog_return_type_t msg_ret = adv_dialog_yes_no(
+                                            get_icon(ICON_HELP), "Remove from cache",
+                                            "Remove app binary from AppFS cache?");
+                                        if (msg_ret == MSG_DIALOG_RETURN_OK) {
+                                            busy_dialog(get_icon(ICON_APPS), "Removing",
+                                                        "Removing from AppFS...", true);
+                                            esp_err_t res = app_mgmt_remove_from_appfs(app->slug);
+                                            if (res == ESP_OK) {
+                                                message_dialog(get_icon(ICON_INFO), "Success",
+                                                               "Removed from AppFS", "OK");
+                                            } else {
+                                                message_dialog(get_icon(ICON_ERROR), "Failed",
+                                                               "Failed to remove from AppFS", "OK");
+                                            }
+                                            refresh = true;
                                         } else {
-                                            message_dialog(get_icon(ICON_ERROR), "Failed", "Failed to install app",
-                                                           "OK");
+                                            render(buffer, theme, &menu, position, false, true);
+                                        }
+                                    } else if (app->executable_type == EXECUTABLE_TYPE_APPFS &&
+                                               app->executable_appfs_fd == APPFS_INVALID_FD) {
+                                        // Not cached → cache (pre-cache without launching)
+                                        char* firmware_path = find_firmware_path(app);
+                                        if (firmware_path == NULL) {
+                                            message_dialog(get_icon(ICON_ERROR), "Error",
+                                                           "App binary not found", "OK");
+                                        } else {
+                                            esp_err_t res = load_app_to_appfs(app, firmware_path);
+                                            free(firmware_path);
+                                            if (res == ESP_OK) {
+                                                message_dialog(get_icon(ICON_INFO), "Success",
+                                                               "App cached in AppFS", "OK");
+                                            }
                                         }
                                         refresh = true;
-                                    } else {
-                                        execute_app(buffer, theme, position, app);
                                     }
-                                    render(buffer, theme, &menu, position, false, false);
                                     break;
                                 }
                                 case BSP_INPUT_NAVIGATION_KEY_MENU:

--- a/main/menu/apps.c
+++ b/main/menu/apps.c
@@ -2,7 +2,9 @@
 #include <esp_log.h>
 #include <stddef.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 #include <sys/syslimits.h>
 #include <time.h>
 #include "app_inspect.h"
@@ -30,6 +32,18 @@
 #include "usb_device.h"
 
 static const char* TAG = "apps";
+
+static int compare_apps_by_name(const void* a, const void* b) {
+    const app_t* app_a = *(const app_t* const*)a;
+    const app_t* app_b = *(const app_t* const*)b;
+    if (app_a == NULL && app_b == NULL) return 0;
+    if (app_a == NULL) return 1;
+    if (app_b == NULL) return -1;
+    if (app_a->name == NULL && app_b->name == NULL) return 0;
+    if (app_a->name == NULL) return 1;
+    if (app_b->name == NULL) return -1;
+    return strcasecmp(app_a->name, app_b->name);
+}
 
 static void populate_menu(menu_t* menu, app_t** apps, size_t app_count) {
     for (size_t i = 0; i < app_count; i++) {
@@ -383,6 +397,7 @@ void menu_apps(pax_buf_t* buffer, gui_theme_t* theme) {
 
         app_t* apps[MAX_NUM_APPS] = {0};
         size_t number_of_apps     = create_list_of_apps(apps, MAX_NUM_APPS);
+        qsort(apps, number_of_apps, sizeof(app_t*), compare_apps_by_name);
 
         menu_t menu = {0};
         menu_initialize(&menu);

--- a/main/menu/apps.c
+++ b/main/menu/apps.c
@@ -268,8 +268,8 @@ static app_menu_footer_type_t previous_footer_type = APP_MENU_FOOTER_TYPE_COUNT;
 
 // Helper to load an app into AppFS on-demand, with auto-cleanup support.
 // Returns ESP_OK on success, error otherwise. Shows dialogs.
-static esp_err_t load_app_to_appfs(app_t* app, const char* firmware_path) {
-    busy_dialog(get_icon(ICON_APPS), "Loading", "Copying app to AppFS...", true);
+static esp_err_t load_app_to_appfs(app_t* app, const char* firmware_path, const char* dialog_title) {
+    busy_dialog(get_icon(ICON_APPS), dialog_title, "Copying app to AppFS...", true);
     esp_err_t res = app_mgmt_cache_to_appfs(app->slug, app->name, app->executable_revision, firmware_path);
     if (res == ESP_ERR_NO_MEM) {
         message_dialog(get_icon(ICON_ERROR), "No space",
@@ -323,7 +323,7 @@ static void render(pax_buf_t* buffer, gui_theme_t* theme, menu_t* menu, pax_vec2
         const char* action_text;
         switch (footer_type) {
             case APP_MENU_FOOTER_TYPE_INSTALL:
-                action_text = "⏎ Cache app";
+                action_text = "⏎ Start app";
                 break;
             case APP_MENU_FOOTER_TYPE_UNAVAILABLE:
                 action_text = "⏎ (Unavailable)";
@@ -438,7 +438,7 @@ void menu_apps(pax_buf_t* buffer, gui_theme_t* theme) {
                                             render(buffer, theme, &menu, position, false, false);
                                             break;
                                         }
-                                        esp_err_t res = load_app_to_appfs(app, firmware_path);
+                                        esp_err_t res = load_app_to_appfs(app, firmware_path, "Loading");
                                         free(firmware_path);
                                         if (res != ESP_OK) {
                                             refresh = true;
@@ -482,7 +482,7 @@ void menu_apps(pax_buf_t* buffer, gui_theme_t* theme) {
                                             message_dialog(get_icon(ICON_ERROR), "Error",
                                                            "App binary not found", "OK");
                                         } else {
-                                            esp_err_t res = load_app_to_appfs(app, firmware_path);
+                                            esp_err_t res = load_app_to_appfs(app, firmware_path, "Caching");
                                             free(firmware_path);
                                             if (res == ESP_OK) {
                                                 message_dialog(get_icon(ICON_INFO), "Success",

--- a/main/menu/apps.c
+++ b/main/menu/apps.c
@@ -31,8 +31,6 @@
 
 static const char* TAG = "apps";
 
-#define MAX_NUM_APPS 128
-
 static void populate_menu(menu_t* menu, app_t** apps, size_t app_count) {
     for (size_t i = 0; i < app_count; i++) {
         if (apps[i] != NULL && apps[i]->slug != NULL && apps[i]->name != NULL) {

--- a/main/menu/apps.c
+++ b/main/menu/apps.c
@@ -10,8 +10,6 @@
 #include "app_metadata_parser.h"
 #include "app_usage.h"
 #include "appfs.h"
-#include "appfs_settings.h"
-#include "fastopen.h"
 #if CONFIG_IDF_TARGET_ESP32P4
 #include "badge_elf.h"
 #endif
@@ -57,47 +55,23 @@ static appfs_handle_t ensure_interpreter_in_appfs(const char* interpreter_slug) 
         return fd;
     }
 
-    // Interpreter not in appfs — try to find its binary in install dirs and load it
-    const char* base_paths[] = {"/int/apps", "/sd/apps"};
-    for (int i = 0; i < 2; i++) {
-        uint32_t revision  = 0;
-        char*    exec_path = NULL;
-        if (get_executable_revision(base_paths[i], interpreter_slug, &revision, &exec_path)) {
-            if (exec_path != NULL && fs_utils_exists(exec_path)) {
-                busy_dialog(get_icon(ICON_APPS), "Loading", "Loading interpreter to AppFS...", true);
-                esp_err_t res = app_mgmt_ensure_in_appfs(interpreter_slug, interpreter_slug, revision, exec_path);
-                if (res == ESP_ERR_NO_MEM) {
-                    uint8_t auto_cleanup = 0;
-                    appfs_settings_get_auto_cleanup(&auto_cleanup);
-                    if (auto_cleanup) {
-                        busy_dialog(get_icon(ICON_APPS), "Loading", "Freeing up space...", true);
-                        FILE* f = fastopen(exec_path, "rb");
-                        if (f != NULL) {
-                            size_t file_size    = fs_utils_get_file_size(f);
-                            fastclose(f);
-                            size_t rounded_size = (file_size + (SPI_FLASH_MMU_PAGE_SIZE - 1)) &
-                                                  (~(SPI_FLASH_MMU_PAGE_SIZE - 1));
-                            app_mgmt_appfs_evict_lru(rounded_size);
-                            busy_dialog(get_icon(ICON_APPS), "Loading", "Loading interpreter to AppFS...", true);
-                            res = app_mgmt_ensure_in_appfs(interpreter_slug, interpreter_slug, revision, exec_path);
-                        }
-                    }
-                    if (res == ESP_ERR_NO_MEM) {
-                        message_dialog(get_icon(ICON_ERROR), "No space",
-                                       "Not enough space in AppFS for interpreter.\nRemove cached apps (F4).", "OK");
-                    }
-                }
-                free(exec_path);
-                if (res == ESP_OK) {
-                    return find_appfs_handle_for_slug(interpreter_slug);
-                }
-                return APPFS_INVALID_FD;
-            }
-            free(exec_path);
-        }
+    char* exec_path = app_mgmt_find_firmware_path(interpreter_slug);
+    if (exec_path == NULL) {
+        message_dialog(get_icon(ICON_ERROR), "Error", "Interpreter binary not found", "OK");
+        return APPFS_INVALID_FD;
     }
 
-    message_dialog(get_icon(ICON_ERROR), "Error", "Interpreter binary not found", "OK");
+    busy_dialog(get_icon(ICON_APPS), "Loading", "Loading interpreter to AppFS...", true);
+    esp_err_t res = app_mgmt_cache_to_appfs(interpreter_slug, interpreter_slug, 0, exec_path);
+    free(exec_path);
+
+    if (res == ESP_ERR_NO_MEM) {
+        message_dialog(get_icon(ICON_ERROR), "No space",
+                       "Not enough space in AppFS for interpreter.\nRemove cached apps (F4).", "OK");
+    }
+    if (res == ESP_OK) {
+        return find_appfs_handle_for_slug(interpreter_slug);
+    }
     return APPFS_INVALID_FD;
 }
 
@@ -294,56 +268,15 @@ typedef enum {
 
 static app_menu_footer_type_t previous_footer_type = APP_MENU_FOOTER_TYPE_COUNT;
 
-// Helper to find firmware path for an app (checks SD then internal install dir)
-// Returns malloc'd string or NULL. Caller must free.
-static char* find_firmware_path(app_t* app) {
-    if (app->executable_on_sd_available && app->executable_on_sd_filename != NULL) {
-        if (fs_utils_exists(app->executable_on_sd_filename)) {
-            return strdup(app->executable_on_sd_filename);
-        }
-    }
-    // Check internal install dir
-    const char* base_paths[] = {"/int/apps", "/sd/apps"};
-    for (int i = 0; i < 2; i++) {
-        uint32_t revision  = 0;
-        char*    exec_path = NULL;
-        if (get_executable_revision(base_paths[i], app->slug, &revision, &exec_path)) {
-            if (exec_path != NULL && fs_utils_exists(exec_path)) {
-                return exec_path;
-            }
-            free(exec_path);
-        }
-    }
-    return NULL;
-}
-
 // Helper to load an app into AppFS on-demand, with auto-cleanup support.
 // Returns ESP_OK on success, error otherwise. Shows dialogs.
 static esp_err_t load_app_to_appfs(app_t* app, const char* firmware_path) {
     busy_dialog(get_icon(ICON_APPS), "Loading", "Copying app to AppFS...", true);
-    esp_err_t res = app_mgmt_ensure_in_appfs(app->slug, app->name, app->executable_revision, firmware_path);
+    esp_err_t res = app_mgmt_cache_to_appfs(app->slug, app->name, app->executable_revision, firmware_path);
     if (res == ESP_ERR_NO_MEM) {
-        uint8_t auto_cleanup = 0;
-        appfs_settings_get_auto_cleanup(&auto_cleanup);
-        if (auto_cleanup) {
-            busy_dialog(get_icon(ICON_APPS), "Loading", "Freeing up space...", true);
-            // Calculate needed size
-            FILE* fd = fastopen(firmware_path, "rb");
-            if (fd != NULL) {
-                size_t file_size    = fs_utils_get_file_size(fd);
-                fastclose(fd);
-                size_t rounded_size = (file_size + (SPI_FLASH_MMU_PAGE_SIZE - 1)) & (~(SPI_FLASH_MMU_PAGE_SIZE - 1));
-                app_mgmt_appfs_evict_lru(rounded_size);
-                busy_dialog(get_icon(ICON_APPS), "Loading", "Copying app to AppFS...", true);
-                res = app_mgmt_ensure_in_appfs(app->slug, app->name, app->executable_revision, firmware_path);
-            }
-        }
-        if (res == ESP_ERR_NO_MEM) {
-            message_dialog(get_icon(ICON_ERROR), "No space",
-                           "Not enough space in AppFS.\nRemove cached apps (F4) to free space.", "OK");
-        }
-    }
-    if (res != ESP_OK && res != ESP_ERR_NO_MEM) {
+        message_dialog(get_icon(ICON_ERROR), "No space",
+                       "Not enough space in AppFS.\nRemove cached apps (F4) to free space.", "OK");
+    } else if (res != ESP_OK) {
         message_dialog(get_icon(ICON_ERROR), "Failed", "Failed to load app to AppFS", "OK");
     }
     return res;
@@ -500,7 +433,7 @@ void menu_apps(pax_buf_t* buffer, gui_theme_t* theme) {
                                     // On-demand AppFS loading for appfs-type apps
                                     if (app->executable_type == EXECUTABLE_TYPE_APPFS &&
                                         app->executable_appfs_fd == APPFS_INVALID_FD) {
-                                        char* firmware_path = find_firmware_path(app);
+                                        char* firmware_path = app_mgmt_find_firmware_path(app->slug);
                                         if (firmware_path == NULL) {
                                             message_dialog(get_icon(ICON_ERROR), "Error",
                                                            "App binary not found", "OK");
@@ -546,7 +479,7 @@ void menu_apps(pax_buf_t* buffer, gui_theme_t* theme) {
                                     } else if (app->executable_type == EXECUTABLE_TYPE_APPFS &&
                                                app->executable_appfs_fd == APPFS_INVALID_FD) {
                                         // Not cached → cache (pre-cache without launching)
-                                        char* firmware_path = find_firmware_path(app);
+                                        char* firmware_path = app_mgmt_find_firmware_path(app->slug);
                                         if (firmware_path == NULL) {
                                             message_dialog(get_icon(ICON_ERROR), "Error",
                                                            "App binary not found", "OK");

--- a/main/menu/apps.c
+++ b/main/menu/apps.c
@@ -392,7 +392,8 @@ void menu_apps(pax_buf_t* buffer, gui_theme_t* theme) {
     QueueHandle_t input_event_queue = NULL;
     ESP_ERROR_CHECK(bsp_input_get_queue(&input_event_queue));
 
-    bool exit = false;
+    bool   exit           = false;
+    size_t saved_position = 0;
     while (!exit) {
 
         app_t* apps[MAX_NUM_APPS] = {0};
@@ -402,6 +403,12 @@ void menu_apps(pax_buf_t* buffer, gui_theme_t* theme) {
         menu_t menu = {0};
         menu_initialize(&menu);
         populate_menu(&menu, apps, number_of_apps);
+
+        // Restore previous position (clamped to list bounds)
+        if (saved_position >= menu_get_length(&menu) && menu_get_length(&menu) > 0) {
+            saved_position = menu_get_length(&menu) - 1;
+        }
+        menu_set_position(&menu, saved_position);
 
         int header_height = theme->header.height + (theme->header.vertical_margin * 2);
         int footer_height = theme->footer.height + (theme->footer.vertical_margin * 2);
@@ -579,6 +586,7 @@ void menu_apps(pax_buf_t* buffer, gui_theme_t* theme) {
                 render(buffer, theme, &menu, position, true, true);
             }
         }
+        saved_position = menu_get_position(&menu);
         menu_free(&menu);
         free_list_of_apps(apps, MAX_NUM_APPS);
     }

--- a/main/menu/apps.c
+++ b/main/menu/apps.c
@@ -12,6 +12,7 @@
 #include "app_metadata_parser.h"
 #include "app_usage.h"
 #include "appfs.h"
+#include "appfs_settings.h"
 #if CONFIG_IDF_TARGET_ESP32P4
 #include "badge_elf.h"
 #endif
@@ -48,10 +49,26 @@ static int compare_apps_by_name(const void* a, const void* b) {
 static void populate_menu(menu_t* menu, app_t** apps, size_t app_count) {
     for (size_t i = 0; i < app_count; i++) {
         if (apps[i] != NULL && apps[i]->slug != NULL && apps[i]->name != NULL) {
-            char label[128];
-            bool in_appfs = (apps[i]->executable_type == EXECUTABLE_TYPE_APPFS &&
-                             apps[i]->executable_appfs_fd != APPFS_INVALID_FD);
-            snprintf(label, sizeof(label), "%s %s", in_appfs ? "[C]" : "   ", apps[i]->name);
+            char        label[128];
+            const char* prefix = "   ";
+            if (apps[i]->executable_type == EXECUTABLE_TYPE_APPFS &&
+                apps[i]->executable_appfs_fd != APPFS_INVALID_FD) {
+                bool mismatch = false;
+                if (apps[i]->executable_on_fs_available) {
+                    // Check revision mismatch
+                    if (apps[i]->executable_on_fs_revision != apps[i]->executable_revision) {
+                        mismatch = true;
+                    }
+                    // Check filesize mismatch
+                    int appfs_size = 0;
+                    appfsEntryInfoExt(apps[i]->executable_appfs_fd, NULL, NULL, NULL, &appfs_size);
+                    if (appfs_size != apps[i]->executable_on_fs_filesize) {
+                        mismatch = true;
+                    }
+                }
+                prefix = mismatch ? "[M]" : "[C]";
+            }
+            snprintf(label, sizeof(label), "%s %s", prefix, apps[i]->name);
             menu_insert_item_icon(menu, label, NULL, (void*)apps[i], -1, apps[i]->icon);
         }
     }
@@ -166,7 +183,7 @@ void execute_app(pax_buf_t* buffer, gui_theme_t* theme, pax_vec2_t position, app
             }
 
             // Update last-used timestamp for the interpreter so it's not evicted prematurely
-            device_settings_set_app_last_used(app->executable_interpreter_slug, (uint32_t)time(NULL));
+            app_usage_set_last_used(app->executable_interpreter_slug, (uint32_t)time(NULL));
 
             size_t req = snprintf(NULL, 0, "%s/%s/%s", app->path, app->slug, app->executable_filename);
             if (req > PATH_MAX) {
@@ -218,14 +235,6 @@ void execute_app(pax_buf_t* buffer, gui_theme_t* theme, pax_vec2_t position, app
                                 {get_icon(ICON_F4), "Uncache"},    \
                                 {get_icon(ICON_F5), "Remove"}}),   \
         5
-#define FOOTER_LEFT_UNCACHE_UPDATE                                 \
-    ((gui_element_icontext_t[]){{get_icon(ICON_ESC), "/"},         \
-                                {get_icon(ICON_F1), "Back"},       \
-                                {get_icon(ICON_F2), "Details"},    \
-                                {get_icon(ICON_F4), "Uncache"},    \
-                                {get_icon(ICON_F5), "Remove"},     \
-                                {get_icon(ICON_F6), "Update"}}),   \
-        6
 #define FOOTER_LEFT_PLAIN                                          \
     ((gui_element_icontext_t[]){{get_icon(ICON_ESC), "/"},         \
                                 {get_icon(ICON_F1), "Back"},       \
@@ -235,7 +244,6 @@ void execute_app(pax_buf_t* buffer, gui_theme_t* theme, pax_vec2_t position, app
 #elif defined(CONFIG_BSP_TARGET_MCH2022) || defined(CONFIG_BSP_TARGET_KAMI)
 #define FOOTER_LEFT_CACHE          NULL, 0
 #define FOOTER_LEFT_UNCACHE        NULL, 0
-#define FOOTER_LEFT_UNCACHE_UPDATE NULL, 0
 #define FOOTER_LEFT_PLAIN          NULL, 0
 #else
 #define FOOTER_LEFT_CACHE                                          \
@@ -252,14 +260,6 @@ void execute_app(pax_buf_t* buffer, gui_theme_t* theme, pax_vec2_t position, app
                                 {NULL, "F4 Uncache"},              \
                                 {NULL, "F5 Remove"}}),             \
         5
-#define FOOTER_LEFT_UNCACHE_UPDATE                                 \
-    ((gui_element_icontext_t[]){{get_icon(ICON_ESC), "/"},         \
-                                {NULL, "F1 Back"},                 \
-                                {NULL, "F2 Details"},              \
-                                {NULL, "F4 Uncache"},              \
-                                {NULL, "F5 Remove"},               \
-                                {NULL, "F6 Update"}}),             \
-        6
 #define FOOTER_LEFT_PLAIN                                          \
     ((gui_element_icontext_t[]){{get_icon(ICON_ESC), "/"},         \
                                 {NULL, "F1 Back"},                 \
@@ -272,7 +272,6 @@ typedef enum {
     APP_MENU_FOOTER_TYPE_NORMAL_CACHED = 0,  // In appfs, has install dir → F4 "Uncache"
     APP_MENU_FOOTER_TYPE_NORMAL_UNCACHED,    // Not in appfs, has install dir → F4 "Cache"
     APP_MENU_FOOTER_TYPE_NORMAL_PLAIN,       // In appfs, no install dir (dev/legacy) → no F4
-    APP_MENU_FOOTER_TYPE_UPDATE_CACHED,      // In appfs, update available → F4 "Uncache" + F6 "Update"
     APP_MENU_FOOTER_TYPE_INSTALL,            // Binary on disk, not in appfs → F4 "Cache"
     APP_MENU_FOOTER_TYPE_UNAVAILABLE,        // Nothing available → no F4
     APP_MENU_FOOTER_TYPE_COUNT,
@@ -305,15 +304,13 @@ static void render(pax_buf_t* buffer, gui_theme_t* theme, menu_t* menu, pax_vec2
         if (app->executable_type == EXECUTABLE_TYPE_APPFS) {
             bool can_uncache = app_mgmt_can_uncache(app->slug);
             if (app->executable_appfs_fd == APPFS_INVALID_FD) {
-                if (app->executable_on_sd_available || app_mgmt_has_binary_in_install_dir(app->slug)) {
+                if (app->executable_on_fs_available || app_mgmt_has_binary_in_install_dir(app->slug)) {
                     footer_type = APP_MENU_FOOTER_TYPE_INSTALL;
                 } else {
                     footer_type = APP_MENU_FOOTER_TYPE_UNAVAILABLE;
                 }
             } else {
-                if (app->executable_on_sd_available && app->executable_on_sd_revision > app->executable_revision) {
-                    footer_type = APP_MENU_FOOTER_TYPE_UPDATE_CACHED;
-                } else if (can_uncache) {
+                if (can_uncache) {
                     footer_type = APP_MENU_FOOTER_TYPE_NORMAL_CACHED;
                 } else {
                     // App only exists in appfs (dev/legacy), no cache toggle available
@@ -369,11 +366,6 @@ static void render(pax_buf_t* buffer, gui_theme_t* theme, menu_t* menu, pax_vec2
                 render_base_screen_statusbar(buffer, theme, !partial, !partial || icons, !partial,
                                              ((gui_element_icontext_t[]){{get_icon(ICON_APPS), "Apps"}}), 1,
                                              FOOTER_LEFT_CACHE, footer_right, 1);
-                break;
-            case APP_MENU_FOOTER_TYPE_UPDATE_CACHED:
-                render_base_screen_statusbar(buffer, theme, !partial, !partial || icons, !partial,
-                                             ((gui_element_icontext_t[]){{get_icon(ICON_APPS), "Apps"}}), 1,
-                                             FOOTER_LEFT_UNCACHE_UPDATE, footer_right, 1);
                 break;
             case APP_MENU_FOOTER_TYPE_UNAVAILABLE:
                 render_base_screen_statusbar(buffer, theme, !partial, !partial || icons, !partial,
@@ -467,6 +459,31 @@ void menu_apps(pax_buf_t* buffer, gui_theme_t* theme) {
                                             break;
                                         }
                                         app->executable_appfs_fd = find_appfs_handle_for_slug(app->slug);
+                                    } else if (app->executable_type == EXECUTABLE_TYPE_APPFS &&
+                                               app->executable_appfs_fd != APPFS_INVALID_FD &&
+                                               app->executable_on_fs_available) {
+                                        // Check for mismatch reinstall
+                                        uint8_t mismatch_reinstall = 0;
+                                        appfs_settings_get_mismatch_reinstall(&mismatch_reinstall);
+                                        if (mismatch_reinstall) {
+                                            int appfs_size = 0;
+                                            appfsEntryInfoExt(app->executable_appfs_fd, NULL, NULL, NULL, &appfs_size);
+                                            bool mismatch = (app->executable_on_fs_revision != app->executable_revision) ||
+                                                            (appfs_size != app->executable_on_fs_filesize);
+                                            if (mismatch) {
+                                                busy_dialog(get_icon(ICON_APPS), "Loading",
+                                                            "Reinstalling to AppFS...", true);
+                                                appfsDeleteFile(app->slug);
+                                                char* firmware_path = app_mgmt_find_firmware_path(app->slug);
+                                                if (firmware_path != NULL) {
+                                                    app_mgmt_cache_to_appfs(app->slug, app->name,
+                                                                            app->executable_on_fs_revision,
+                                                                            firmware_path);
+                                                    free(firmware_path);
+                                                }
+                                                app->executable_appfs_fd = find_appfs_handle_for_slug(app->slug);
+                                            }
+                                        }
                                     }
                                     execute_app(buffer, theme, position, app);
                                     render(buffer, theme, &menu, position, false, false);
@@ -485,10 +502,7 @@ void menu_apps(pax_buf_t* buffer, gui_theme_t* theme) {
                                             busy_dialog(get_icon(ICON_APPS), "Removing",
                                                         "Removing from AppFS...", true);
                                             esp_err_t res = app_mgmt_remove_from_appfs(app->slug);
-                                            if (res == ESP_OK) {
-                                                message_dialog(get_icon(ICON_INFO), "Success",
-                                                               "Removed from AppFS", "OK");
-                                            } else {
+                                            if (res != ESP_OK) {
                                                 message_dialog(get_icon(ICON_ERROR), "Failed",
                                                                "Failed to remove from AppFS", "OK");
                                             }
@@ -504,12 +518,8 @@ void menu_apps(pax_buf_t* buffer, gui_theme_t* theme) {
                                             message_dialog(get_icon(ICON_ERROR), "Error",
                                                            "App binary not found", "OK");
                                         } else {
-                                            esp_err_t res = load_app_to_appfs(app, firmware_path, "Caching");
+                                            load_app_to_appfs(app, firmware_path, "Caching");
                                             free(firmware_path);
-                                            if (res == ESP_OK) {
-                                                message_dialog(get_icon(ICON_INFO), "Success",
-                                                               "App cached in AppFS", "OK");
-                                            }
                                         }
                                         refresh = true;
                                     }
@@ -536,10 +546,7 @@ void menu_apps(pax_buf_t* buffer, gui_theme_t* theme) {
                                     if (msg_ret == MSG_DIALOG_RETURN_OK) {
                                         esp_err_t res_int = app_mgmt_uninstall(app->slug, APP_MGMT_LOCATION_INTERNAL);
                                         esp_err_t res_sd  = app_mgmt_uninstall(app->slug, APP_MGMT_LOCATION_SD);
-                                        if (res_int == ESP_OK || res_sd == ESP_OK) {
-                                            message_dialog(get_icon(ICON_INFO), "Success", "App removed successfully",
-                                                           "OK");
-                                        } else {
+                                        if (res_int != ESP_OK && res_sd != ESP_OK) {
                                             message_dialog(get_icon(ICON_ERROR), "Failed", "Failed to remove app",
                                                            "OK");
                                         }
@@ -547,30 +554,6 @@ void menu_apps(pax_buf_t* buffer, gui_theme_t* theme) {
                                     } else {
                                         render(buffer, theme, &menu, position, false, true);
                                     }
-                                    break;
-                                }
-                                case BSP_INPUT_NAVIGATION_KEY_F6: {
-                                    void*  arg = menu_get_callback_args(&menu, menu_get_position(&menu));
-                                    app_t* app = (app_t*)arg;
-                                    if (app->executable_type == EXECUTABLE_TYPE_APPFS &&
-                                        app->executable_on_sd_available &&
-                                        app->executable_revision != app->executable_on_sd_revision) {
-                                        // Install from SD card
-                                        busy_dialog(get_icon(ICON_APPS), "Updating", "Updating application...", true);
-                                        esp_err_t res = app_mgmt_install_from_file(app->slug, app->name,
-                                                                                   app->executable_on_sd_revision,
-                                                                                   app->executable_on_sd_filename);
-                                        if (res == ESP_OK) {
-                                            message_dialog(get_icon(ICON_INFO), "Success", "App updated successfully",
-                                                           "OK");
-                                        } else {
-                                            message_dialog(get_icon(ICON_ERROR), "Failed", "Failed to update app",
-                                                           "OK");
-                                        }
-                                    } else {
-                                        message_dialog(get_icon(ICON_ERROR), "Failed", "Nothing to update", "OK");
-                                    }
-                                    refresh = true;
                                     break;
                                 }
                                 default:

--- a/main/menu/apps.c
+++ b/main/menu/apps.c
@@ -51,7 +51,9 @@ static void populate_menu(menu_t* menu, app_t** apps, size_t app_count) {
         if (apps[i] != NULL && apps[i]->slug != NULL && apps[i]->name != NULL) {
             char        label[128];
             const char* prefix = "   ";
-            if (apps[i]->executable_type == EXECUTABLE_TYPE_APPFS &&
+            if (apps[i]->executable_type == EXECUTABLE_TYPE_SCRIPT) {
+                prefix = "[S]";
+            } else if (apps[i]->executable_type == EXECUTABLE_TYPE_APPFS &&
                 apps[i]->executable_appfs_fd != APPFS_INVALID_FD) {
                 bool mismatch = false;
                 if (apps[i]->executable_on_fs_available) {
@@ -297,7 +299,7 @@ static void render(pax_buf_t* buffer, gui_theme_t* theme, menu_t* menu, pax_vec2
     void*  arg = menu_get_callback_args(menu, menu_get_position(menu));
     app_t* app = (app_t*)arg;
 
-    app_menu_footer_type_t footer_type = APP_MENU_FOOTER_TYPE_NORMAL_UNCACHED;
+    app_menu_footer_type_t footer_type = APP_MENU_FOOTER_TYPE_NORMAL_PLAIN;
     if (app == NULL) {
         footer_type = APP_MENU_FOOTER_TYPE_UNAVAILABLE;
     } else {
@@ -492,6 +494,7 @@ void menu_apps(pax_buf_t* buffer, gui_theme_t* theme) {
                                 case BSP_INPUT_NAVIGATION_KEY_F4: {
                                     void*  arg = menu_get_callback_args(&menu, menu_get_position(&menu));
                                     app_t* app = (app_t*)arg;
+                                    if (app->executable_type != EXECUTABLE_TYPE_APPFS) break;
                                     if (app->executable_appfs_fd != APPFS_INVALID_FD &&
                                         app_mgmt_can_uncache(app->slug)) {
                                         // Cached → uncache

--- a/main/menu/apps.c
+++ b/main/menu/apps.c
@@ -179,6 +179,9 @@ void execute_app(pax_buf_t* buffer, gui_theme_t* theme, pax_vec2_t position, app
                 return;
             }
 
+            // Update last-used timestamp for the interpreter so it's not evicted prematurely
+            device_settings_set_app_last_used(app->executable_interpreter_slug, (uint32_t)time(NULL));
+
             size_t req = snprintf(NULL, 0, "%s/%s/%s", app->path, app->slug, app->executable_filename);
             if (req > PATH_MAX) {
                 message_dialog(get_icon(ICON_ERROR), "Error", "Script path is too long", "OK");

--- a/main/menu/menu_repository_client.c
+++ b/main/menu/menu_repository_client.c
@@ -1,13 +1,18 @@
 #include "menu_repository_client.h"
+#include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
+#include "app_management.h"
+#include "app_metadata_parser.h"
+#include "bsp/device.h"
 #include "bsp/input.h"
 #include "cJSON.h"
 #include "common/display.h"
 #include "device_settings.h"
 #include "esp_log.h"
+#include "filesystem_utils.h"
 #include "gui_menu.h"
 #include "gui_style.h"
 #include "http_download.h"
@@ -51,11 +56,90 @@ repository_json_data_t projects = {0};
 #define ICON_COLOR_FORMAT PAX_BUF_32_8888ARGB
 #endif
 
+typedef enum {
+    INSTALL_STATUS_NOT_INSTALLED = 0,
+    INSTALL_STATUS_INSTALLED,
+    INSTALL_STATUS_UPDATE_AVAILABLE,
+} install_status_t;
+
 typedef struct {
-    const char* name;
-    int         index;
-    pax_buf_t*  icon;
+    const char*      name;
+    const char*      slug;
+    int              index;
+    pax_buf_t*       icon;
+    install_status_t     status;
+    app_mgmt_location_t install_location;  // Where the app is installed (if applicable)
 } project_sort_entry_t;
+
+// Read the "version" field from an installed app's metadata.json.
+// Returns a malloc'd string or NULL. Caller must free.
+static char* get_installed_version(const char* base_path, const char* slug) {
+    char path[256];
+    snprintf(path, sizeof(path), "%s/%s/metadata.json", base_path, slug);
+
+    FILE* fd = fopen(path, "r");
+    if (fd == NULL) return NULL;
+
+    fseek(fd, 0, SEEK_END);
+    size_t fsize = ftell(fd);
+    fseek(fd, 0, SEEK_SET);
+    char* data = malloc(fsize + 1);
+    if (data == NULL) {
+        fclose(fd);
+        return NULL;
+    }
+    fread(data, 1, fsize, fd);
+    data[fsize] = '\0';
+    fclose(fd);
+
+    cJSON* root = cJSON_Parse(data);
+    free(data);
+    if (root == NULL) return NULL;
+
+    char* version = NULL;
+    cJSON* version_obj = cJSON_GetObjectItem(root, "version");
+    if (version_obj != NULL && cJSON_IsString(version_obj)) {
+        version = strdup(version_obj->valuestring);
+    } else if (version_obj != NULL && cJSON_IsNumber(version_obj)) {
+        size_t len = snprintf(NULL, 0, "%d", version_obj->valueint);
+        version = malloc(len + 1);
+        if (version != NULL) {
+            snprintf(version, len + 1, "%d", version_obj->valueint);
+        }
+    }
+
+    cJSON_Delete(root);
+    return version;
+}
+
+// Check install status of an app by slug. Compares version strings.
+// Sets location if installed.
+static install_status_t check_install_status(const char* slug, const char* repo_version,
+                                              app_mgmt_location_t* out_location) {
+    const char* base_paths[]    = {"/sd/apps", "/int/apps"};  // SD priority
+    app_mgmt_location_t locs[] = {APP_MGMT_LOCATION_SD, APP_MGMT_LOCATION_INTERNAL};
+
+    for (int i = 0; i < 2; i++) {
+        char check_path[256];
+        snprintf(check_path, sizeof(check_path), "%s/%s", base_paths[i], slug);
+        if (!fs_utils_exists(check_path)) continue;
+
+        if (out_location != NULL) {
+            *out_location = locs[i];
+        }
+
+        char* installed_version = get_installed_version(base_paths[i], slug);
+        if (installed_version == NULL) {
+            return INSTALL_STATUS_INSTALLED;  // Installed but can't read version
+        }
+
+        bool versions_match = (repo_version != NULL && strcmp(installed_version, repo_version) == 0);
+        free(installed_version);
+
+        return versions_match ? INSTALL_STATUS_INSTALLED : INSTALL_STATUS_UPDATE_AVAILABLE;
+    }
+    return INSTALL_STATUS_NOT_INSTALLED;
+}
 
 // Decode a base64-encoded PNG into a pax_buf_t. Returns NULL on failure.
 static pax_buf_t* decode_base64_icon(const char* base64_data) {
@@ -105,6 +189,29 @@ static void free_menu_icons(menu_t* menu) {
     }
 }
 
+// Parallel array of install status, indexed by menu position (after sorting).
+// Allocated in populate_project_list, freed by caller.
+static install_status_t*    project_statuses   = NULL;
+static app_mgmt_location_t* project_locations  = NULL;
+static int*                 project_indices    = NULL;
+static int                  project_count      = 0;
+static bool                 has_updates        = false;
+
+static cJSON* get_project_by_index(cJSON* json_projects, int index) {
+    return cJSON_GetArrayItem(json_projects, index);
+}
+
+static void free_project_info(void) {
+    free(project_statuses);
+    free(project_locations);
+    free(project_indices);
+    project_statuses  = NULL;
+    project_locations = NULL;
+    project_indices   = NULL;
+    project_count     = 0;
+    has_updates       = false;
+}
+
 static int compare_projects_by_name(const void* a, const void* b) {
     const project_sort_entry_t* ea = (const project_sort_entry_t*)a;
     const project_sort_entry_t* eb = (const project_sort_entry_t*)b;
@@ -150,8 +257,23 @@ static void populate_project_list(menu_t* menu, cJSON* json_projects) {
             continue;
         }
         sorted[i].name  = name_obj->valuestring;
+        sorted[i].slug  = slug_obj->valuestring;
         sorted[i].index = idx;
         sorted[i].icon  = NULL;
+
+        // Check install status by comparing version strings
+        sorted[i].install_location = APP_MGMT_LOCATION_INTERNAL;
+        cJSON* version_obj = cJSON_GetObjectItem(project_obj, "version");
+        char   repo_version_buf[32] = {0};
+        const char* repo_version    = NULL;
+        if (version_obj != NULL && cJSON_IsString(version_obj)) {
+            repo_version = version_obj->valuestring;
+        } else if (version_obj != NULL && cJSON_IsNumber(version_obj)) {
+            snprintf(repo_version_buf, sizeof(repo_version_buf), "%d", version_obj->valueint);
+            repo_version = repo_version_buf;
+        }
+        sorted[i].status = check_install_status(slug_obj->valuestring, repo_version,
+                                                 &sorted[i].install_location);
 
         // Decode optional base64 icon
         cJSON* icon_obj = cJSON_GetObjectItem(entry_obj, "icon");
@@ -165,17 +287,52 @@ static void populate_project_list(menu_t* menu, cJSON* json_projects) {
 
     qsort(sorted, i, sizeof(project_sort_entry_t), compare_projects_by_name);
 
+    // Save status info in parallel arrays (indexed by menu position after sort)
+    free_project_info();
+    project_statuses  = malloc(sizeof(install_status_t) * i);
+    project_locations = malloc(sizeof(app_mgmt_location_t) * i);
+    project_indices   = malloc(sizeof(int) * i);
+    project_count     = i;
+    has_updates       = false;
+
     for (int j = 0; j < i; j++) {
-        printf("Project: %s\r\n", sorted[j].name);
-        menu_insert_item_icon(menu, sorted[j].name, NULL, (void*)sorted[j].index, -1, sorted[j].icon);
+        const char* prefix;
+        switch (sorted[j].status) {
+            case INSTALL_STATUS_UPDATE_AVAILABLE:
+                prefix      = "[U]";
+                has_updates = true;
+                break;
+            case INSTALL_STATUS_INSTALLED:
+                prefix = "[I]";
+                break;
+            default:
+                prefix = "   ";
+                break;
+        }
+        char label[128];
+        snprintf(label, sizeof(label), "%s %s", prefix, sorted[j].name);
+        menu_insert_item_icon(menu, label, NULL, (void*)sorted[j].index, -1, sorted[j].icon);
+
+        if (project_statuses)  project_statuses[j]  = sorted[j].status;
+        if (project_locations) project_locations[j] = sorted[j].install_location;
+        if (project_indices)   project_indices[j]   = sorted[j].index;
     }
 
     free(sorted);
 }
 
-static cJSON* get_project_by_index(cJSON* json_projects, int index) {
-    return cJSON_GetArrayItem(json_projects, index);
+static void download_callback(size_t download_position, size_t file_size, const char* status_text) {
+    if (file_size == 0) return;
+    uint8_t        percentage      = 100 * download_position / file_size;
+    static uint8_t last_percentage = 0;
+    if (percentage == last_percentage) return;
+    last_percentage = percentage;
+    char text[64];
+    snprintf(text, sizeof(text), "%s (%u%%)", status_text ? status_text : "Downloading", percentage);
+    busy_dialog(get_icon(ICON_DOWNLOADING), "Downloading", text, true);
 }
+
+static install_status_t previous_render_status = INSTALL_STATUS_NOT_INSTALLED;
 
 static void render(pax_buf_t* buffer, gui_theme_t* theme, menu_t* menu, const char* server, bool partial, bool icons) {
     int header_height = theme->header.height + (theme->header.vertical_margin * 2);
@@ -188,22 +345,60 @@ static void render(pax_buf_t* buffer, gui_theme_t* theme, menu_t* menu, const ch
         .y1 = pax_buf_get_height(buffer) - footer_height - theme->menu.vertical_margin - theme->menu.vertical_padding,
     };
 
+    // Check if footer needs redrawing due to status change of selected item
+    install_status_t current_status = INSTALL_STATUS_NOT_INSTALLED;
+    size_t           pos            = menu_get_position(menu);
+    if (pos < (size_t)project_count && project_statuses != NULL) {
+        current_status = project_statuses[pos];
+    }
+    if (current_status != previous_render_status) {
+        previous_render_status = current_status;
+        partial = false;
+    }
+
     if (!partial || icons) {
+        // Determine action text based on selected item's install status
+        const char* action_text;
+        switch (current_status) {
+            case INSTALL_STATUS_UPDATE_AVAILABLE:
+                action_text = "⏎ Update";
+                break;
+            case INSTALL_STATUS_INSTALLED:
+                action_text = "⏎ Re-Install";
+                break;
+            default:
+                action_text = "⏎ Install";
+                break;
+        }
+
+        char footer_right_text[64];
+        snprintf(footer_right_text, sizeof(footer_right_text), "↑ / ↓ | %s", action_text);
+
         char server_info[160];
         snprintf(server_info, sizeof(server_info), "Server: %s", server);
 #if defined(CONFIG_BSP_TARGET_TANMATSU) || defined(CONFIG_BSP_TARGET_KONSOOL)
-        render_base_screen_statusbar(buffer, theme, !partial, !partial || icons, !partial,
-                                     ((gui_element_icontext_t[]){{get_icon(ICON_STOREFRONT), "Repository"}}), 1,
-                                     ((gui_element_icontext_t[]){
-                                         {get_icon(ICON_ESC), "/"},
-                                         {get_icon(ICON_F1), "Back    "},
-                                         {get_icon(ICON_GLOBE), server_info},
-                                     }),
-                                     3, ((gui_element_icontext_t[]){{NULL, "  ↑ / ↓ | ⏎ Select"}}), 1);
+        if (has_updates) {
+            render_base_screen_statusbar(buffer, theme, !partial, !partial || icons, !partial,
+                                         ((gui_element_icontext_t[]){{get_icon(ICON_STOREFRONT), "Repository"}}), 1,
+                                         ((gui_element_icontext_t[]){
+                                             {get_icon(ICON_ESC), "/"},
+                                             {get_icon(ICON_F1), "Back"},
+                                             {get_icon(ICON_F6), "Update all"},
+                                         }),
+                                         3, ((gui_element_icontext_t[]){{NULL, footer_right_text}}), 1);
+        } else {
+            render_base_screen_statusbar(buffer, theme, !partial, !partial || icons, !partial,
+                                         ((gui_element_icontext_t[]){{get_icon(ICON_STOREFRONT), "Repository"}}), 1,
+                                         ((gui_element_icontext_t[]){
+                                             {get_icon(ICON_ESC), "/"},
+                                             {get_icon(ICON_F1), "Back"},
+                                         }),
+                                         2, ((gui_element_icontext_t[]){{NULL, footer_right_text}}), 1);
+        }
 #else
         render_base_screen_statusbar(buffer, theme, !partial, !partial || icons, !partial,
                                      ((gui_element_icontext_t[]){{get_icon(ICON_STOREFRONT), "Repository"}}), 1,
-                                     FOOTER_LEFT, FOOTER_RIGHT);
+                                     FOOTER_LEFT, ((gui_element_icontext_t[]){{NULL, footer_right_text}}), 1);
 #endif
     }
     menu_render(buffer, menu, position, theme, partial);
@@ -260,6 +455,7 @@ void menu_repository_client(pax_buf_t* buffer, gui_theme_t* theme) {
                             case BSP_INPUT_NAVIGATION_KEY_ESC:
                             case BSP_INPUT_NAVIGATION_KEY_F1:
                             case BSP_INPUT_NAVIGATION_KEY_GAMEPAD_B:
+                                free_project_info();
                                 free_menu_icons(&menu);
                                 menu_free(&menu);
                                 return;
@@ -274,13 +470,92 @@ void menu_repository_client(pax_buf_t* buffer, gui_theme_t* theme) {
                             case BSP_INPUT_NAVIGATION_KEY_RETURN:
                             case BSP_INPUT_NAVIGATION_KEY_GAMEPAD_A:
                             case BSP_INPUT_NAVIGATION_KEY_JOYSTICK_PRESS: {
-                                void*  arg     = menu_get_callback_args(&menu, menu_get_position(&menu));
-                                cJSON* wrapper = get_project_by_index(projects.json, (int)(arg));
-                                if (wrapper == NULL) {
-                                    ESP_LOGE(TAG, "Wrapper object is NULL");
-                                    break;
+                                size_t pos = menu_get_position(&menu);
+                                if (pos < (size_t)project_count && project_statuses != NULL &&
+                                    project_statuses[pos] != INSTALL_STATUS_NOT_INSTALLED) {
+                                    // Update or re-install: confirm, use existing location
+                                    const char* action_name =
+                                        (project_statuses[pos] == INSTALL_STATUS_UPDATE_AVAILABLE)
+                                            ? "Update" : "Re-install";
+                                    char confirm_msg[128];
+                                    cJSON* wrapper = get_project_by_index(projects.json, project_indices[pos]);
+                                    cJSON* slug_obj = wrapper ? cJSON_GetObjectItem(wrapper, "slug") : NULL;
+                                    snprintf(confirm_msg, sizeof(confirm_msg), "%s this app?", action_name);
+                                    message_dialog_return_type_t msg_ret = adv_dialog_yes_no(
+                                        get_icon(ICON_HELP), action_name, confirm_msg);
+                                    if (msg_ret == MSG_DIALOG_RETURN_OK && slug_obj != NULL) {
+                                        busy_dialog(get_icon(ICON_STOREFRONT), "Repository",
+                                                    "Installing...", true);
+                                        app_mgmt_install(server, slug_obj->valuestring,
+                                                         project_locations[pos], download_callback);
+                                    }
+                                    // Rebuild menu to refresh status markers
+                                    free_menu_icons(&menu);
+                                    menu_free(&menu);
+                                    menu_initialize(&menu);
+                                    size_t saved_pos = pos;
+                                    populate_project_list(&menu, projects.json);
+                                    if (saved_pos >= menu_get_length(&menu) && menu_get_length(&menu) > 0) {
+                                        saved_pos = menu_get_length(&menu) - 1;
+                                    }
+                                    menu_set_position(&menu, saved_pos);
+                                } else {
+                                    // Not installed: open project detail with location picker
+                                    void*  arg     = menu_get_callback_args(&menu, pos);
+                                    cJSON* wrapper = get_project_by_index(projects.json, (int)(arg));
+                                    if (wrapper == NULL) {
+                                        ESP_LOGE(TAG, "Wrapper object is NULL");
+                                        break;
+                                    }
+                                    menu_repository_client_project(buffer, theme, wrapper);
                                 }
-                                menu_repository_client_project(buffer, theme, wrapper);
+                                render(buffer, theme, &menu, server, false, true);
+                                break;
+                            }
+                            case BSP_INPUT_NAVIGATION_KEY_F6: {
+                                if (!has_updates) break;
+                                message_dialog_return_type_t msg_ret = adv_dialog_yes_no(
+                                    get_icon(ICON_HELP), "Update all",
+                                    "Update all apps with available updates?");
+                                if (msg_ret == MSG_DIALOG_RETURN_OK) {
+                                    int updated = 0;
+                                    int failed  = 0;
+                                    int total   = 0;
+                                    for (int j = 0; j < project_count; j++) {
+                                        if (project_statuses[j] != INSTALL_STATUS_UPDATE_AVAILABLE) continue;
+                                        total++;
+                                        cJSON* wrapper  = get_project_by_index(projects.json, project_indices[j]);
+                                        cJSON* slug_obj = wrapper ? cJSON_GetObjectItem(wrapper, "slug") : NULL;
+                                        if (slug_obj == NULL) { failed++; continue; }
+                                        char msg[64];
+                                        snprintf(msg, sizeof(msg), "Updating %s (%d/%d)...",
+                                                 slug_obj->valuestring, updated + failed + 1, total);
+                                        busy_dialog(get_icon(ICON_STOREFRONT), "Updating", msg, true);
+                                        esp_err_t res = app_mgmt_install(server, slug_obj->valuestring,
+                                                                          project_locations[j], download_callback);
+                                        if (res == ESP_OK) {
+                                            updated++;
+                                        } else {
+                                            failed++;
+                                        }
+                                    }
+                                    if (failed > 0) {
+                                        char summary[64];
+                                        snprintf(summary, sizeof(summary),
+                                                 "Updated %d/%d apps. %d failed.", updated, total, failed);
+                                        message_dialog(get_icon(ICON_ERROR), "Update all", summary, "OK");
+                                    }
+                                    // Rebuild menu to refresh status markers
+                                    size_t saved_pos = menu_get_position(&menu);
+                                    free_menu_icons(&menu);
+                                    menu_free(&menu);
+                                    menu_initialize(&menu);
+                                    populate_project_list(&menu, projects.json);
+                                    if (saved_pos >= menu_get_length(&menu) && menu_get_length(&menu) > 0) {
+                                        saved_pos = menu_get_length(&menu) - 1;
+                                    }
+                                    menu_set_position(&menu, saved_pos);
+                                }
                                 render(buffer, theme, &menu, server, false, true);
                                 break;
                             }

--- a/main/menu/menu_repository_client.c
+++ b/main/menu/menu_repository_client.c
@@ -1,6 +1,8 @@
 #include "menu_repository_client.h"
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 #include "bsp/input.h"
 #include "cJSON.h"
 #include "common/display.h"
@@ -48,29 +50,69 @@ repository_json_data_t projects = {0};
 #define ICON_COLOR_FORMAT PAX_BUF_32_8888ARGB
 #endif
 
+typedef struct {
+    const char* name;
+    int         index;
+} project_sort_entry_t;
+
+static int compare_projects_by_name(const void* a, const void* b) {
+    const project_sort_entry_t* ea = (const project_sort_entry_t*)a;
+    const project_sort_entry_t* eb = (const project_sort_entry_t*)b;
+    return strcasecmp(ea->name, eb->name);
+}
+
 static void populate_project_list(menu_t* menu, cJSON* json_projects) {
+    // Count valid entries
+    int    total = 0;
     cJSON* entry_obj;
-    int    i = 0;
+    cJSON_ArrayForEach(entry_obj, json_projects) {
+        cJSON* project_obj = cJSON_GetObjectItem(entry_obj, "project");
+        if (project_obj != NULL && cJSON_GetObjectItem(project_obj, "name") != NULL) {
+            total++;
+        }
+    }
+
+    if (total == 0) return;
+
+    // Collect entries for sorting
+    project_sort_entry_t* sorted = malloc(sizeof(project_sort_entry_t) * total);
+    if (sorted == NULL) return;
+
+    int i = 0;
+    int idx = 0;
     cJSON_ArrayForEach(entry_obj, json_projects) {
         cJSON* slug_obj = cJSON_GetObjectItem(entry_obj, "slug");
         if (slug_obj == NULL) {
-            ESP_LOGE(TAG, "Slug object is NULL for entry %d", i);
+            ESP_LOGE(TAG, "Slug object is NULL for entry %d", idx);
+            idx++;
             continue;
         }
         cJSON* project_obj = cJSON_GetObjectItem(entry_obj, "project");
         if (project_obj == NULL) {
-            ESP_LOGE(TAG, "Project object is NULL for entry %d", i);
+            ESP_LOGE(TAG, "Project object is NULL for entry %d", idx);
+            idx++;
             continue;
         }
         cJSON* name_obj = cJSON_GetObjectItem(project_obj, "name");
         if (name_obj == NULL) {
-            ESP_LOGE(TAG, "Name object is NULL for entry %d", i);
+            ESP_LOGE(TAG, "Name object is NULL for entry %d", idx);
+            idx++;
             continue;
         }
-        printf("Project [%s]: %s\r\n", slug_obj->valuestring, name_obj->valuestring);
-        menu_insert_item(menu, name_obj->valuestring, NULL, (void*)i, -1);
+        sorted[i].name  = name_obj->valuestring;
+        sorted[i].index = idx;
         i++;
+        idx++;
     }
+
+    qsort(sorted, i, sizeof(project_sort_entry_t), compare_projects_by_name);
+
+    for (int j = 0; j < i; j++) {
+        printf("Project: %s\r\n", sorted[j].name);
+        menu_insert_item(menu, sorted[j].name, NULL, (void*)sorted[j].index, -1);
+    }
+
+    free(sorted);
 }
 
 static cJSON* get_project_by_index(cJSON* json_projects, int index) {

--- a/main/menu/menu_repository_client.c
+++ b/main/menu/menu_repository_client.c
@@ -377,23 +377,23 @@ static void render(pax_buf_t* buffer, gui_theme_t* theme, menu_t* menu, const ch
         char server_info[160];
         snprintf(server_info, sizeof(server_info), "Server: %s", server);
 #if defined(CONFIG_BSP_TARGET_TANMATSU) || defined(CONFIG_BSP_TARGET_KONSOOL)
-        if (has_updates) {
+        {
+            bool is_installed = (current_status == INSTALL_STATUS_INSTALLED ||
+                                 current_status == INSTALL_STATUS_UPDATE_AVAILABLE);
+            gui_element_icontext_t footer_left[4];
+            int                    footer_left_count = 0;
+            footer_left[footer_left_count++] = (gui_element_icontext_t){get_icon(ICON_ESC), "/"};
+            footer_left[footer_left_count++] = (gui_element_icontext_t){get_icon(ICON_F1), "Back"};
+            if (is_installed) {
+                footer_left[footer_left_count++] = (gui_element_icontext_t){get_icon(ICON_F5), "Remove"};
+            }
+            if (has_updates) {
+                footer_left[footer_left_count++] = (gui_element_icontext_t){get_icon(ICON_F6), "Update all"};
+            }
             render_base_screen_statusbar(buffer, theme, !partial, !partial || icons, !partial,
                                          ((gui_element_icontext_t[]){{get_icon(ICON_STOREFRONT), "Repository"}}), 1,
-                                         ((gui_element_icontext_t[]){
-                                             {get_icon(ICON_ESC), "/"},
-                                             {get_icon(ICON_F1), "Back"},
-                                             {get_icon(ICON_F6), "Update all"},
-                                         }),
-                                         3, ((gui_element_icontext_t[]){{NULL, footer_right_text}}), 1);
-        } else {
-            render_base_screen_statusbar(buffer, theme, !partial, !partial || icons, !partial,
-                                         ((gui_element_icontext_t[]){{get_icon(ICON_STOREFRONT), "Repository"}}), 1,
-                                         ((gui_element_icontext_t[]){
-                                             {get_icon(ICON_ESC), "/"},
-                                             {get_icon(ICON_F1), "Back"},
-                                         }),
-                                         2, ((gui_element_icontext_t[]){{NULL, footer_right_text}}), 1);
+                                         footer_left, footer_left_count,
+                                         ((gui_element_icontext_t[]){{NULL, footer_right_text}}), 1);
         }
 #else
         render_base_screen_statusbar(buffer, theme, !partial, !partial || icons, !partial,
@@ -508,6 +508,44 @@ void menu_repository_client(pax_buf_t* buffer, gui_theme_t* theme) {
                                         break;
                                     }
                                     menu_repository_client_project(buffer, theme, wrapper);
+                                    // Rebuild menu to refresh status markers (app may have been installed)
+                                    free_menu_icons(&menu);
+                                    menu_free(&menu);
+                                    menu_initialize(&menu);
+                                    populate_project_list(&menu, projects.json);
+                                    if (pos >= menu_get_length(&menu) && menu_get_length(&menu) > 0) {
+                                        pos = menu_get_length(&menu) - 1;
+                                    }
+                                    menu_set_position(&menu, pos);
+                                }
+                                render(buffer, theme, &menu, server, false, true);
+                                break;
+                            }
+                            case BSP_INPUT_NAVIGATION_KEY_F5: {
+                                size_t pos = menu_get_position(&menu);
+                                if (pos >= (size_t)project_count || project_statuses == NULL) break;
+                                if (project_statuses[pos] == INSTALL_STATUS_NOT_INSTALLED) break;
+
+                                cJSON* wrapper  = get_project_by_index(projects.json, project_indices[pos]);
+                                cJSON* slug_obj = wrapper ? cJSON_GetObjectItem(wrapper, "slug") : NULL;
+                                if (slug_obj == NULL) break;
+
+                                message_dialog_return_type_t msg_ret = adv_dialog_yes_no(
+                                    get_icon(ICON_HELP), "Delete App",
+                                    "Do you really want to delete the app?");
+                                if (msg_ret == MSG_DIALOG_RETURN_OK) {
+                                    app_mgmt_uninstall(slug_obj->valuestring, APP_MGMT_LOCATION_INTERNAL);
+                                    app_mgmt_uninstall(slug_obj->valuestring, APP_MGMT_LOCATION_SD);
+
+                                    // Rebuild menu to refresh status markers
+                                    free_menu_icons(&menu);
+                                    menu_free(&menu);
+                                    menu_initialize(&menu);
+                                    populate_project_list(&menu, projects.json);
+                                    if (pos >= menu_get_length(&menu) && menu_get_length(&menu) > 0) {
+                                        pos = menu_get_length(&menu) - 1;
+                                    }
+                                    menu_set_position(&menu, pos);
                                 }
                                 render(buffer, theme, &menu, server, false, true);
                                 break;

--- a/main/menu/menu_repository_client.c
+++ b/main/menu/menu_repository_client.c
@@ -12,6 +12,7 @@
 #include "gui_style.h"
 #include "http_download.h"
 #include "icons.h"
+#include "mbedtls/base64.h"
 #include "menu/message_dialog.h"
 #include "menu_repository_client_project.h"
 #include "nvs_settings.h"
@@ -53,7 +54,56 @@ repository_json_data_t projects = {0};
 typedef struct {
     const char* name;
     int         index;
+    pax_buf_t*  icon;
 } project_sort_entry_t;
+
+// Decode a base64-encoded PNG into a pax_buf_t. Returns NULL on failure.
+static pax_buf_t* decode_base64_icon(const char* base64_data) {
+    size_t b64_len = strlen(base64_data);
+    size_t decoded_len = 0;
+
+    // Get decoded size
+    if (mbedtls_base64_decode(NULL, 0, &decoded_len, (const unsigned char*)base64_data, b64_len) != MBEDTLS_ERR_BASE64_BUFFER_TOO_SMALL) {
+        return NULL;
+    }
+
+    uint8_t* png_data = malloc(decoded_len);
+    if (png_data == NULL) {
+        return NULL;
+    }
+
+    size_t actual_len = 0;
+    if (mbedtls_base64_decode(png_data, decoded_len, &actual_len, (const unsigned char*)base64_data, b64_len) != 0) {
+        free(png_data);
+        return NULL;
+    }
+
+    pax_buf_t* icon = calloc(1, sizeof(pax_buf_t));
+    if (icon == NULL) {
+        free(png_data);
+        return NULL;
+    }
+
+    if (!pax_decode_png_buf(icon, png_data, actual_len, ICON_COLOR_FORMAT, 0)) {
+        free(icon);
+        free(png_data);
+        return NULL;
+    }
+
+    free(png_data);
+    return icon;
+}
+
+// Free all icons attached to menu items
+static void free_menu_icons(menu_t* menu) {
+    for (size_t i = 0; i < menu_get_length(menu); i++) {
+        pax_buf_t* icon = menu_get_icon(menu, i);
+        if (icon != NULL) {
+            pax_buf_destroy(icon);
+            free(icon);
+        }
+    }
+}
 
 static int compare_projects_by_name(const void* a, const void* b) {
     const project_sort_entry_t* ea = (const project_sort_entry_t*)a;
@@ -101,6 +151,14 @@ static void populate_project_list(menu_t* menu, cJSON* json_projects) {
         }
         sorted[i].name  = name_obj->valuestring;
         sorted[i].index = idx;
+        sorted[i].icon  = NULL;
+
+        // Decode optional base64 icon
+        cJSON* icon_obj = cJSON_GetObjectItem(entry_obj, "icon");
+        if (icon_obj != NULL && cJSON_IsString(icon_obj)) {
+            sorted[i].icon = decode_base64_icon(icon_obj->valuestring);
+        }
+
         i++;
         idx++;
     }
@@ -109,7 +167,7 @@ static void populate_project_list(menu_t* menu, cJSON* json_projects) {
 
     for (int j = 0; j < i; j++) {
         printf("Project: %s\r\n", sorted[j].name);
-        menu_insert_item(menu, sorted[j].name, NULL, (void*)sorted[j].index, -1);
+        menu_insert_item_icon(menu, sorted[j].name, NULL, (void*)sorted[j].index, -1, sorted[j].icon);
     }
 
     free(sorted);
@@ -202,6 +260,7 @@ void menu_repository_client(pax_buf_t* buffer, gui_theme_t* theme) {
                             case BSP_INPUT_NAVIGATION_KEY_ESC:
                             case BSP_INPUT_NAVIGATION_KEY_F1:
                             case BSP_INPUT_NAVIGATION_KEY_GAMEPAD_B:
+                                free_menu_icons(&menu);
                                 menu_free(&menu);
                                 return;
                             case BSP_INPUT_NAVIGATION_KEY_UP:

--- a/main/menu/menu_repository_client_project.c
+++ b/main/menu/menu_repository_client_project.c
@@ -1,8 +1,12 @@
 #include "menu_repository_client_project.h"
+#include <ctype.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/_intsup.h>
 #include "app_management.h"
+#include "app_metadata_parser.h"
+#include "appfs.h"
+#include "bsp/device.h"
 #include "bsp/input.h"
 #include "cJSON.h"
 #include "common/display.h"
@@ -108,34 +112,197 @@ static void download_callback(size_t download_position, size_t file_size, const 
     busy_dialog(get_icon(ICON_DOWNLOADING), "Downloading", text, true);
 };
 
+// Find the interpreter slug for the current device from project metadata.
+// Returns NULL if the app is not a script type or has no interpreter.
+// The returned string points into the cJSON tree — do not free.
+static const char* find_interpreter_slug(cJSON* project) {
+    cJSON* applications = cJSON_GetObjectItem(project, "application");
+    if (applications == NULL || !cJSON_IsArray(applications)) {
+        return NULL;
+    }
+
+    char device_name[32] = {0};
+    bsp_device_get_name(device_name, sizeof(device_name));
+    for (int i = 0; device_name[i]; i++) {
+        device_name[i] = tolower(device_name[i]);
+    }
+
+    cJSON* application = NULL;
+    cJSON_ArrayForEach(application, applications) {
+        cJSON* targets = cJSON_GetObjectItem(application, "targets");
+        if (targets == NULL || !cJSON_IsArray(targets)) {
+            continue;
+        }
+        cJSON* target = NULL;
+        bool   matched = false;
+        cJSON_ArrayForEach(target, targets) {
+            if (target != NULL && cJSON_IsString(target) &&
+                strcmp(target->valuestring, device_name) == 0 &&
+                strlen(target->valuestring) == strlen(device_name)) {
+                matched = true;
+                break;
+            }
+        }
+        if (matched) {
+            cJSON* type_obj = cJSON_GetObjectItem(application, "type");
+            if (type_obj != NULL && cJSON_IsString(type_obj) &&
+                strcmp(type_obj->valuestring, "script") == 0) {
+                cJSON* interp_obj = cJSON_GetObjectItem(application, "interpreter");
+                if (interp_obj != NULL && cJSON_IsString(interp_obj)) {
+                    return interp_obj->valuestring;
+                }
+            }
+            return NULL;  // Found matching app but it's not a script
+        }
+    }
+    return NULL;
+}
+
+// Check if interpreter is already available (in appfs or install dirs)
+static bool interpreter_available(const char* interpreter_slug) {
+    if (appfsExists(interpreter_slug)) {
+        return true;
+    }
+    return app_mgmt_has_binary_in_install_dir(interpreter_slug);
+}
+
+// Prompt user to install the interpreter and handle the download
+static void prompt_install_interpreter(pax_buf_t* buffer, gui_theme_t* theme, const char* interpreter_slug) {
+    char msg[128];
+    snprintf(msg, sizeof(msg), "This app requires interpreter '%s'.\nInstall it?", interpreter_slug);
+    message_dialog_return_type_t result = adv_dialog_yes_no(get_icon(ICON_HELP), "Interpreter needed", msg);
+    if (result != MSG_DIALOG_RETURN_OK) {
+        return;
+    }
+
+    // Ask where to install
+    QueueHandle_t input_event_queue = NULL;
+    ESP_ERROR_CHECK(bsp_input_get_queue(&input_event_queue));
+
+    menu_t loc_menu = {0};
+    menu_initialize(&loc_menu);
+    menu_insert_item(&loc_menu, "Install on\nSD card", NULL, (void*)ACTION_INSTALL_SD, -1);
+    menu_insert_item(&loc_menu, "Install on\nInternal memory", NULL, (void*)ACTION_INSTALL, -1);
+
+    int header_height = theme->header.height + (theme->header.vertical_margin * 2);
+    int footer_height = theme->footer.height + (theme->footer.vertical_margin * 2);
+
+    render_base_screen_statusbar(
+        buffer, theme, true, true, true,
+        ((gui_element_icontext_t[]){{get_icon(ICON_STOREFRONT), "Install interpreter"}}), 1,
+        ((gui_element_icontext_t[]){{get_icon(ICON_ESC), "/"}, {get_icon(ICON_F1), "Skip"}}), 2,
+        ((gui_element_icontext_t[]){{NULL, "← / → | ⏎ Select"}}), 1);
+
+    pax_vec2_t menu_position = {
+        .x0 = pax_buf_get_width(buffer) - theme->menu.horizontal_margin - theme->menu.horizontal_padding - 400,
+        .y0 = pax_buf_get_height(buffer) - footer_height - theme->menu.vertical_margin - theme->menu.vertical_padding -
+              128,
+        .x1 = pax_buf_get_width(buffer) - theme->menu.horizontal_margin - theme->menu.horizontal_padding,
+        .y1 = pax_buf_get_height(buffer) - footer_height - theme->menu.vertical_margin - theme->menu.vertical_padding,
+    };
+
+    gui_theme_t modified_theme                = *theme;
+    modified_theme.menu.grid_horizontal_count = menu_get_length(&loc_menu);
+    modified_theme.menu.grid_vertical_count   = 1;
+    menu_render_grid(buffer, &loc_menu, menu_position, &modified_theme, false);
+    display_blit_buffer(buffer);
+
+    while (1) {
+        bsp_input_event_t event;
+        if (xQueueReceive(input_event_queue, &event, pdMS_TO_TICKS(1000)) == pdTRUE) {
+            if (event.type == INPUT_EVENT_TYPE_NAVIGATION && event.args_navigation.state) {
+                switch (event.args_navigation.key) {
+                    case BSP_INPUT_NAVIGATION_KEY_ESC:
+                    case BSP_INPUT_NAVIGATION_KEY_F1:
+                    case BSP_INPUT_NAVIGATION_KEY_GAMEPAD_B:
+                        menu_free(&loc_menu);
+                        return;
+                    case BSP_INPUT_NAVIGATION_KEY_LEFT:
+                        menu_navigate_previous(&loc_menu);
+                        menu_render_grid(buffer, &loc_menu, menu_position, &modified_theme, true);
+                        display_blit_buffer(buffer);
+                        break;
+                    case BSP_INPUT_NAVIGATION_KEY_RIGHT:
+                        menu_navigate_next(&loc_menu);
+                        menu_render_grid(buffer, &loc_menu, menu_position, &modified_theme, true);
+                        display_blit_buffer(buffer);
+                        break;
+                    case BSP_INPUT_NAVIGATION_KEY_RETURN:
+                    case BSP_INPUT_NAVIGATION_KEY_GAMEPAD_A:
+                    case BSP_INPUT_NAVIGATION_KEY_JOYSTICK_PRESS: {
+                        void*               arg = menu_get_callback_args(&loc_menu, menu_get_position(&loc_menu));
+                        app_mgmt_location_t location = ((menu_repository_client_project_action_t)arg == ACTION_INSTALL)
+                                                           ? APP_MGMT_LOCATION_INTERNAL
+                                                           : APP_MGMT_LOCATION_SD;
+                        const char* loc_text = (location == APP_MGMT_LOCATION_SD) ? "SD card" : "internal memory";
+                        char        busy_msg[64];
+                        snprintf(busy_msg, sizeof(busy_msg), "Installing interpreter on %s...", loc_text);
+                        busy_dialog(get_icon(ICON_STOREFRONT), "Repository", busy_msg, true);
+
+                        char server[128] = {0};
+                        device_settings_get_repo_server(server, sizeof(server));
+                        esp_err_t res = app_mgmt_install(server, interpreter_slug, location, download_callback);
+                        if (res == ESP_OK) {
+                            message_dialog(get_icon(ICON_STOREFRONT), "Repository",
+                                           "Interpreter installed successfully", "OK");
+                        } else {
+                            message_dialog(get_icon(ICON_ERROR), "Repository",
+                                           "Interpreter not found in repository.\n"
+                                           "You may need to install it manually.",
+                                           "OK");
+                        }
+                        menu_free(&loc_menu);
+                        return;
+                    }
+                    default:
+                        break;
+                }
+            }
+        }
+    }
+}
+
 static void execute_action(pax_buf_t* buffer, menu_repository_client_project_action_t action, gui_theme_t* theme,
                            cJSON* wrapper) {
     char server[128] = {0};
     nvs_settings_get_repo_server(server, sizeof(server), DEFAULT_REPO_SERVER);
 
     cJSON* slug_obj = cJSON_GetObjectItem(wrapper, "slug");
+    cJSON* project  = cJSON_GetObjectItem(wrapper, "project");
+
+    app_mgmt_location_t location;
+    const char*         loc_text;
     switch (action) {
-        case ACTION_INSTALL: {
-            busy_dialog(get_icon(ICON_STOREFRONT), "Repository", "Installing on internal memory...", true);
-            if (app_mgmt_install(server, slug_obj->valuestring, APP_MGMT_LOCATION_INTERNAL, download_callback) !=
-                ESP_OK) {
-                message_dialog(get_icon(ICON_ERROR), "Repository", "Installation failed", "OK");
-            } else {
-                message_dialog(get_icon(ICON_STOREFRONT), "Repository", "App successfully installed", "OK");
-            }
+        case ACTION_INSTALL:
+            location = APP_MGMT_LOCATION_INTERNAL;
+            loc_text = "internal memory";
             break;
-        }
-        case ACTION_INSTALL_SD: {
-            busy_dialog(get_icon(ICON_STOREFRONT), "Repository", "Installing on SD card...", true);
-            if (app_mgmt_install(server, slug_obj->valuestring, APP_MGMT_LOCATION_SD, download_callback) != ESP_OK) {
-                message_dialog(get_icon(ICON_ERROR), "Repository", "Installation failed", "OK, download_callback");
-            } else {
-                message_dialog(get_icon(ICON_STOREFRONT), "Repository", "App successfully installed", "OK");
-            }
+        case ACTION_INSTALL_SD:
+            location = APP_MGMT_LOCATION_SD;
+            loc_text = "SD card";
             break;
-        }
         default:
-            break;
+            return;
+    }
+
+    char busy_msg[64];
+    snprintf(busy_msg, sizeof(busy_msg), "Installing on %s...", loc_text);
+    busy_dialog(get_icon(ICON_STOREFRONT), "Repository", busy_msg, true);
+
+    esp_err_t res = app_mgmt_install(server, slug_obj->valuestring, location, download_callback);
+    if (res != ESP_OK) {
+        message_dialog(get_icon(ICON_ERROR), "Repository", "Installation failed", "OK");
+        return;
+    }
+
+    message_dialog(get_icon(ICON_STOREFRONT), "Repository", "App successfully installed", "OK");
+
+    // Check if this is a script app that needs an interpreter
+    if (project != NULL) {
+        const char* interpreter_slug = find_interpreter_slug(project);
+        if (interpreter_slug != NULL && !interpreter_available(interpreter_slug)) {
+            prompt_install_interpreter(buffer, theme, interpreter_slug);
+        }
     }
 }
 

--- a/main/menu/menu_repository_client_project.c
+++ b/main/menu/menu_repository_client_project.c
@@ -184,7 +184,6 @@ static void prompt_install_interpreter(pax_buf_t* buffer, gui_theme_t* theme, co
     menu_insert_item(&loc_menu, "Install on\nSD card", NULL, (void*)ACTION_INSTALL_SD, -1);
     menu_insert_item(&loc_menu, "Install on\nInternal memory", NULL, (void*)ACTION_INSTALL, -1);
 
-    int header_height = theme->header.height + (theme->header.vertical_margin * 2);
     int footer_height = theme->footer.height + (theme->footer.vertical_margin * 2);
 
     render_base_screen_statusbar(

--- a/main/menu/menu_repository_client_project.c
+++ b/main/menu/menu_repository_client_project.c
@@ -178,7 +178,7 @@ static void prompt_install_interpreter(pax_buf_t* buffer, gui_theme_t* theme, co
 
     // Fetch interpreter project metadata from repo
     char server[128] = {0};
-    device_settings_get_repo_server(server, sizeof(server));
+    nvs_settings_get_repo_server(server, sizeof(server), DEFAULT_REPO_SERVER);
 
     busy_dialog(get_icon(ICON_STOREFRONT), "Repository", "Loading interpreter info...", true);
     repository_json_data_t interp_data = {0};

--- a/main/menu/menu_repository_client_project.c
+++ b/main/menu/menu_repository_client_project.c
@@ -20,6 +20,7 @@
 #include "pax_fonts.h"
 #include "pax_text.h"
 #include "pax_types.h"
+#include "repository_client.h"
 
 static const char* TAG = "Repository client: project";
 
@@ -166,7 +167,7 @@ static bool interpreter_available(const char* interpreter_slug) {
     return app_mgmt_has_binary_in_install_dir(interpreter_slug);
 }
 
-// Prompt user to install the interpreter and handle the download
+// Prompt user to install the interpreter using the standard project install dialog
 static void prompt_install_interpreter(pax_buf_t* buffer, gui_theme_t* theme, const char* interpreter_slug) {
     char msg[128];
     snprintf(msg, sizeof(msg), "This app requires interpreter '%s'.\nInstall it?", interpreter_slug);
@@ -175,90 +176,27 @@ static void prompt_install_interpreter(pax_buf_t* buffer, gui_theme_t* theme, co
         return;
     }
 
-    // Ask where to install
-    QueueHandle_t input_event_queue = NULL;
-    ESP_ERROR_CHECK(bsp_input_get_queue(&input_event_queue));
+    // Fetch interpreter project metadata from repo
+    char server[128] = {0};
+    device_settings_get_repo_server(server, sizeof(server));
 
-    menu_t loc_menu = {0};
-    menu_initialize(&loc_menu);
-    menu_insert_item(&loc_menu, "Install on\nSD card", NULL, (void*)ACTION_INSTALL_SD, -1);
-    menu_insert_item(&loc_menu, "Install on\nInternal memory", NULL, (void*)ACTION_INSTALL, -1);
-
-    int footer_height = theme->footer.height + (theme->footer.vertical_margin * 2);
-
-    render_base_screen_statusbar(
-        buffer, theme, true, true, true,
-        ((gui_element_icontext_t[]){{get_icon(ICON_STOREFRONT), "Install interpreter"}}), 1,
-        ((gui_element_icontext_t[]){{get_icon(ICON_ESC), "/"}, {get_icon(ICON_F1), "Skip"}}), 2,
-        ((gui_element_icontext_t[]){{NULL, "← / → | ⏎ Select"}}), 1);
-
-    pax_vec2_t menu_position = {
-        .x0 = pax_buf_get_width(buffer) - theme->menu.horizontal_margin - theme->menu.horizontal_padding - 400,
-        .y0 = pax_buf_get_height(buffer) - footer_height - theme->menu.vertical_margin - theme->menu.vertical_padding -
-              128,
-        .x1 = pax_buf_get_width(buffer) - theme->menu.horizontal_margin - theme->menu.horizontal_padding,
-        .y1 = pax_buf_get_height(buffer) - footer_height - theme->menu.vertical_margin - theme->menu.vertical_padding,
-    };
-
-    gui_theme_t modified_theme                = *theme;
-    modified_theme.menu.grid_horizontal_count = menu_get_length(&loc_menu);
-    modified_theme.menu.grid_vertical_count   = 1;
-    menu_render_grid(buffer, &loc_menu, menu_position, &modified_theme, false);
-    display_blit_buffer(buffer);
-
-    while (1) {
-        bsp_input_event_t event;
-        if (xQueueReceive(input_event_queue, &event, pdMS_TO_TICKS(1000)) == pdTRUE) {
-            if (event.type == INPUT_EVENT_TYPE_NAVIGATION && event.args_navigation.state) {
-                switch (event.args_navigation.key) {
-                    case BSP_INPUT_NAVIGATION_KEY_ESC:
-                    case BSP_INPUT_NAVIGATION_KEY_F1:
-                    case BSP_INPUT_NAVIGATION_KEY_GAMEPAD_B:
-                        menu_free(&loc_menu);
-                        return;
-                    case BSP_INPUT_NAVIGATION_KEY_LEFT:
-                        menu_navigate_previous(&loc_menu);
-                        menu_render_grid(buffer, &loc_menu, menu_position, &modified_theme, true);
-                        display_blit_buffer(buffer);
-                        break;
-                    case BSP_INPUT_NAVIGATION_KEY_RIGHT:
-                        menu_navigate_next(&loc_menu);
-                        menu_render_grid(buffer, &loc_menu, menu_position, &modified_theme, true);
-                        display_blit_buffer(buffer);
-                        break;
-                    case BSP_INPUT_NAVIGATION_KEY_RETURN:
-                    case BSP_INPUT_NAVIGATION_KEY_GAMEPAD_A:
-                    case BSP_INPUT_NAVIGATION_KEY_JOYSTICK_PRESS: {
-                        void*               arg = menu_get_callback_args(&loc_menu, menu_get_position(&loc_menu));
-                        app_mgmt_location_t location = ((menu_repository_client_project_action_t)arg == ACTION_INSTALL)
-                                                           ? APP_MGMT_LOCATION_INTERNAL
-                                                           : APP_MGMT_LOCATION_SD;
-                        const char* loc_text = (location == APP_MGMT_LOCATION_SD) ? "SD card" : "internal memory";
-                        char        busy_msg[64];
-                        snprintf(busy_msg, sizeof(busy_msg), "Installing interpreter on %s...", loc_text);
-                        busy_dialog(get_icon(ICON_STOREFRONT), "Repository", busy_msg, true);
-
-                        char server[128] = {0};
-                        device_settings_get_repo_server(server, sizeof(server));
-                        esp_err_t res = app_mgmt_install(server, interpreter_slug, location, download_callback);
-                        if (res == ESP_OK) {
-                            message_dialog(get_icon(ICON_STOREFRONT), "Repository",
-                                           "Interpreter installed successfully", "OK");
-                        } else {
-                            message_dialog(get_icon(ICON_ERROR), "Repository",
-                                           "Interpreter not found in repository.\n"
-                                           "You may need to install it manually.",
-                                           "OK");
-                        }
-                        menu_free(&loc_menu);
-                        return;
-                    }
-                    default:
-                        break;
-                }
-            }
-        }
+    busy_dialog(get_icon(ICON_STOREFRONT), "Repository", "Loading interpreter info...", true);
+    repository_json_data_t interp_data = {0};
+    if (!load_project(server, &interp_data, interpreter_slug)) {
+        message_dialog(get_icon(ICON_ERROR), "Repository",
+                       "Interpreter not found in repository.\nYou may need to install it manually.", "OK");
+        return;
     }
+
+    // Build a wrapper object like the project list entries have: {"slug": "...", "project": {...}}
+    cJSON* wrapper = cJSON_CreateObject();
+    cJSON_AddStringToObject(wrapper, "slug", interpreter_slug);
+    cJSON_AddItemToObject(wrapper, "project", cJSON_Duplicate(interp_data.json, true));
+    free_repository_data_json(&interp_data);
+
+    // Use the standard project install dialog
+    menu_repository_client_project(buffer, theme, wrapper);
+    cJSON_Delete(wrapper);
 }
 
 static void execute_action(pax_buf_t* buffer, menu_repository_client_project_action_t action, gui_theme_t* theme,

--- a/main/menu/settings_repository.c
+++ b/main/menu/settings_repository.c
@@ -87,7 +87,7 @@ static void edit_server(pax_buf_t* buffer, gui_theme_t* theme, menu_t* menu) {
     menu_textedit(buffer, theme, "Server", server, sizeof(server), false, &accepted);
     if (accepted) {
         nvs_settings_set_repo_server(server);
-        menu_set_value(menu, 0, server);
+        menu_populate(menu);
     }
 }
 
@@ -99,7 +99,7 @@ static void edit_base_uri(pax_buf_t* buffer, gui_theme_t* theme, menu_t* menu) {
     menu_textedit(buffer, theme, "Base URI", base_uri, sizeof(base_uri), false, &accepted);
     if (accepted) {
         nvs_settings_set_repo_base_uri(base_uri);
-        menu_set_value(menu, 1, base_uri);
+        menu_populate(menu);
     }
 }
 
@@ -114,7 +114,7 @@ static void edit_user_agent(pax_buf_t* buffer, gui_theme_t* theme, menu_t* menu)
     menu_textedit(buffer, theme, "User Agent", user_agent, sizeof(user_agent), false, &accepted);
     if (accepted) {
         nvs_settings_set_http_user_agent(user_agent);
-        menu_set_value(menu, 2, user_agent);
+        menu_populate(menu);
     }
 }
 
@@ -127,11 +127,7 @@ static void reset_defaults(menu_t* menu) {
     nvs_settings_set_http_user_agent(default_ua);
     appfs_settings_set_auto_cleanup(DEFAULT_APPFS_AUTO_CLEANUP);
     appfs_settings_set_mismatch_reinstall(DEFAULT_APPFS_MISMATCH_REINSTALL);
-    menu_set_value(menu, 0, DEFAULT_REPO_SERVER);
-    menu_set_value(menu, 1, DEFAULT_REPO_BASE_URI);
-    menu_set_value(menu, 2, default_ua);
-    menu_set_value(menu, 3, "Disabled");
-    menu_set_value(menu, 4, "Disabled");
+    menu_populate(menu);
 }
 
 void menu_settings_repository(void) {
@@ -176,7 +172,13 @@ void menu_settings_repository(void) {
                                 render(buffer, theme, &menu, position, true, false);
                                 break;
                             case BSP_INPUT_NAVIGATION_KEY_F4:
-                                reset_defaults(&menu);
+                                if (event.args_navigation.modifiers & BSP_INPUT_MODIFIER_CTRL) {
+                                    nvs_settings_set_repo_server("https://cavac.at/tanmatsu");
+                                    nvs_settings_set_repo_base_uri("/v1");
+                                    menu_populate(&menu);
+                                } else {
+                                    reset_defaults(&menu);
+                                }
                                 render(buffer, theme, &menu, position, false, true);
                                 break;
                             case BSP_INPUT_NAVIGATION_KEY_RETURN:
@@ -200,7 +202,7 @@ void menu_settings_repository(void) {
                                         appfs_settings_get_auto_cleanup(&current);
                                         current = current ? 0 : 1;
                                         appfs_settings_set_auto_cleanup(current);
-                                        menu_set_value(&menu, 3, current ? "Enabled" : "Disabled");
+                                        menu_populate(&menu);
                                         break;
                                     }
                                     case ACTION_MISMATCH_REINSTALL: {
@@ -208,7 +210,7 @@ void menu_settings_repository(void) {
                                         appfs_settings_get_mismatch_reinstall(&current);
                                         current = current ? 0 : 1;
                                         appfs_settings_set_mismatch_reinstall(current);
-                                        menu_set_value(&menu, 4, current ? "Enabled" : "Disabled");
+                                        menu_populate(&menu);
                                         break;
                                     }
                                     default:

--- a/main/menu/settings_repository.c
+++ b/main/menu/settings_repository.c
@@ -1,5 +1,6 @@
 #include "settings_repository.h"
 #include <string.h>
+#include "appfs_settings.h"
 #include "bsp/input.h"
 #include "common/display.h"
 #include "common/theme.h"
@@ -26,6 +27,7 @@ typedef enum {
     ACTION_SERVER,
     ACTION_BASE_URI,
     ACTION_USER_AGENT,
+    ACTION_AUTO_CLEANUP,
 } menu_repo_settings_action_t;
 
 static void render(pax_buf_t* buffer, gui_theme_t* theme, menu_t* menu, pax_vec2_t position, bool partial, bool icons) {
@@ -59,9 +61,13 @@ static void menu_populate(menu_t* menu) {
         menu_remove_item(menu, 0);
     }
 
+    uint8_t auto_cleanup = 0;
+    appfs_settings_get_auto_cleanup(&auto_cleanup);
+
     menu_insert_item_value(menu, "Server", server, NULL, (void*)ACTION_SERVER, -1);
     menu_insert_item_value(menu, "Base URI", base_uri, NULL, (void*)ACTION_BASE_URI, -1);
     menu_insert_item_value(menu, "User Agent", user_agent, NULL, (void*)ACTION_USER_AGENT, -1);
+    menu_insert_item_value(menu, "Auto-cleanup AppFS", auto_cleanup ? "X" : "", NULL, (void*)ACTION_AUTO_CLEANUP, -1);
 
     if (previous_position >= menu_get_length(menu)) {
         previous_position = menu_get_length(menu) - 1;
@@ -115,9 +121,11 @@ static void reset_defaults(menu_t* menu) {
     nvs_settings_set_repo_server(DEFAULT_REPO_SERVER);
     nvs_settings_set_repo_base_uri(DEFAULT_REPO_BASE_URI);
     nvs_settings_set_http_user_agent(default_ua);
+    appfs_settings_set_auto_cleanup(DEFAULT_APPFS_AUTO_CLEANUP);
     menu_set_value(menu, 0, DEFAULT_REPO_SERVER);
     menu_set_value(menu, 1, DEFAULT_REPO_BASE_URI);
     menu_set_value(menu, 2, default_ua);
+    menu_set_value(menu, 3, "");
 }
 
 void menu_settings_repository(void) {
@@ -181,6 +189,14 @@ void menu_settings_repository(void) {
                                     case ACTION_USER_AGENT:
                                         edit_user_agent(buffer, theme, &menu);
                                         break;
+                                    case ACTION_AUTO_CLEANUP: {
+                                        uint8_t current = 0;
+                                        appfs_settings_get_auto_cleanup(&current);
+                                        current = current ? 0 : 1;
+                                        appfs_settings_set_auto_cleanup(current);
+                                        menu_set_value(&menu, 3, current ? "X" : "");
+                                        break;
+                                    }
                                     default:
                                         break;
                                 }

--- a/main/menu/settings_repository.c
+++ b/main/menu/settings_repository.c
@@ -67,7 +67,7 @@ static void menu_populate(menu_t* menu) {
     menu_insert_item_value(menu, "Server", server, NULL, (void*)ACTION_SERVER, -1);
     menu_insert_item_value(menu, "Base URI", base_uri, NULL, (void*)ACTION_BASE_URI, -1);
     menu_insert_item_value(menu, "User Agent", user_agent, NULL, (void*)ACTION_USER_AGENT, -1);
-    menu_insert_item_value(menu, "Auto-cleanup AppFS", auto_cleanup ? "X" : "", NULL, (void*)ACTION_AUTO_CLEANUP, -1);
+    menu_insert_item_value(menu, "Auto-cleanup AppFS", auto_cleanup ? "Enabled" : "Disabled", NULL, (void*)ACTION_AUTO_CLEANUP, -1);
 
     if (previous_position >= menu_get_length(menu)) {
         previous_position = menu_get_length(menu) - 1;
@@ -125,7 +125,7 @@ static void reset_defaults(menu_t* menu) {
     menu_set_value(menu, 0, DEFAULT_REPO_SERVER);
     menu_set_value(menu, 1, DEFAULT_REPO_BASE_URI);
     menu_set_value(menu, 2, default_ua);
-    menu_set_value(menu, 3, "");
+    menu_set_value(menu, 3, "Disabled");
 }
 
 void menu_settings_repository(void) {
@@ -194,7 +194,7 @@ void menu_settings_repository(void) {
                                         appfs_settings_get_auto_cleanup(&current);
                                         current = current ? 0 : 1;
                                         appfs_settings_set_auto_cleanup(current);
-                                        menu_set_value(&menu, 3, current ? "X" : "");
+                                        menu_set_value(&menu, 3, current ? "Enabled" : "Disabled");
                                         break;
                                     }
                                     default:

--- a/main/menu/settings_repository.c
+++ b/main/menu/settings_repository.c
@@ -28,6 +28,7 @@ typedef enum {
     ACTION_BASE_URI,
     ACTION_USER_AGENT,
     ACTION_AUTO_CLEANUP,
+    ACTION_MISMATCH_REINSTALL,
 } menu_repo_settings_action_t;
 
 static void render(pax_buf_t* buffer, gui_theme_t* theme, menu_t* menu, pax_vec2_t position, bool partial, bool icons) {
@@ -63,11 +64,14 @@ static void menu_populate(menu_t* menu) {
 
     uint8_t auto_cleanup = 0;
     appfs_settings_get_auto_cleanup(&auto_cleanup);
+    uint8_t mismatch_reinstall = 0;
+    appfs_settings_get_mismatch_reinstall(&mismatch_reinstall);
 
     menu_insert_item_value(menu, "Server", server, NULL, (void*)ACTION_SERVER, -1);
     menu_insert_item_value(menu, "Base URI", base_uri, NULL, (void*)ACTION_BASE_URI, -1);
     menu_insert_item_value(menu, "User Agent", user_agent, NULL, (void*)ACTION_USER_AGENT, -1);
     menu_insert_item_value(menu, "Auto-cleanup AppFS", auto_cleanup ? "Enabled" : "Disabled", NULL, (void*)ACTION_AUTO_CLEANUP, -1);
+    menu_insert_item_value(menu, "On AppFS mismatch auto-reinstall", mismatch_reinstall ? "Enabled" : "Disabled", NULL, (void*)ACTION_MISMATCH_REINSTALL, -1);
 
     if (previous_position >= menu_get_length(menu)) {
         previous_position = menu_get_length(menu) - 1;
@@ -122,10 +126,12 @@ static void reset_defaults(menu_t* menu) {
     nvs_settings_set_repo_base_uri(DEFAULT_REPO_BASE_URI);
     nvs_settings_set_http_user_agent(default_ua);
     appfs_settings_set_auto_cleanup(DEFAULT_APPFS_AUTO_CLEANUP);
+    appfs_settings_set_mismatch_reinstall(DEFAULT_APPFS_MISMATCH_REINSTALL);
     menu_set_value(menu, 0, DEFAULT_REPO_SERVER);
     menu_set_value(menu, 1, DEFAULT_REPO_BASE_URI);
     menu_set_value(menu, 2, default_ua);
     menu_set_value(menu, 3, "Disabled");
+    menu_set_value(menu, 4, "Disabled");
 }
 
 void menu_settings_repository(void) {
@@ -195,6 +201,14 @@ void menu_settings_repository(void) {
                                         current = current ? 0 : 1;
                                         appfs_settings_set_auto_cleanup(current);
                                         menu_set_value(&menu, 3, current ? "Enabled" : "Disabled");
+                                        break;
+                                    }
+                                    case ACTION_MISMATCH_REINSTALL: {
+                                        uint8_t current = 0;
+                                        appfs_settings_get_mismatch_reinstall(&current);
+                                        current = current ? 0 : 1;
+                                        appfs_settings_set_mismatch_reinstall(current);
+                                        menu_set_value(&menu, 4, current ? "Enabled" : "Disabled");
                                         break;
                                     }
                                     default:


### PR DESCRIPTION
1) Fully automatic appfs management with the option to go manual for app dev purposes
2) Properly sorted app lists in both "Apps" and "Repository"
3) Display of available and free appfs space in the Apps dialog (and options to cache/uncache binaries to appfs)
4) Keeping your place (selected line) in Apps for certain operations
5) Display app icons in the Repo downloader (no extra webcalls, requires small server change on your part; backwards compatible to existing server; simply add an "icon" entry into the project list with the base64 encoded 32x32 icon png)
6) You can move installed apps between /int and /sd via the app details
7) The Repo downloader now shows which Apps are already installed, which installed Apps need and update and gives you the option to update all installed apps
8) Full support for "script" type apps, including suggesting downloading the correct interpreter