### PR TITLE
Auto-connect to saved WiFi on boot regardless of NTP setting

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -147,8 +147,12 @@ static void wifi_task(void* pvParameters) {
     }
 #endif
 
+    // Always try to auto-connect to a saved WiFi network on boot, so launcher
+    // and apps have network access without manual reconnect after each reboot.
+    bool wifi_ok = (wifi_connect_try_all() == ESP_OK);
+
     if (ntp_get_enabled()) {
-        if (wifi_connect_try_all() == ESP_OK) {
+        if (wifi_ok) {
             esp_err_t res = ntp_start_service("pool.ntp.org");
             if (res == ESP_OK) {
                 res = ntp_sync_wait();


### PR DESCRIPTION
## Summary

Auto-connects to a saved WiFi network on boot unconditionally, instead of only when NTP is enabled. The result is reused for the existing NTP branch so behaviour is preserved when NTP is on.

## Motivation

Before: launcher only calls `wifi_connect_try_all()` if `ntp_get_enabled()` is true, so users with NTP off had to manually reconnect to their saved network after every reboot — even though one was already configured. Apps that need network access (firmware OTA from the launcher, sensor uploads, MeshCore-style time sync via SNTP from inside an app, etc.) start with no link until the user opens the WiFi menu.

After: a saved network is restored on boot regardless of the NTP toggle. NTP behaviour is unchanged — same wait/start sequence, just driven off the cached connect result.

## Test plan

- Built launcher at this commit on `esp32p4` target → boots, attempts `wifi_connect_try_all()` once
- With saved network present + NTP off: WiFi link comes up before apps start (previously did not)
- With NTP on: behaviour unchanged — same NTP-start sequence runs after a successful connect
- No saved network: `wifi_connect_try_all()` returns non-OK, NTP path is skipped same as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
